### PR TITLE
added reshape to call to scatter() to correct minor error

### DIFF
--- a/wmpl/Trajectory/Trajectory.py
+++ b/wmpl/Trajectory/Trajectory.py
@@ -4544,7 +4544,7 @@ class Trajectory(object):
 
             # Plot all point to point velocities
             ax1.scatter(obs.velocities[1:]/1000, obs.time_data[1:], marker=vel_markers[i%len(vel_markers)], 
-                c=colors[i], alpha=alpha, label='Station: {:s}'.format(str(obs.station_id)), zorder=3)
+                c=colors[i].reshape(1,-1), alpha=alpha, label='Station: {:s}'.format(str(obs.station_id)), zorder=3)
 
 
             # Determine the max/min velocity and height, as this is needed for plotting both height/time axes


### PR DESCRIPTION
the *c* parameter to scatter should be a tuple, but a single value is being passed in when the velocity scattergraph is called. Matplotlib issues a warning about this. It can be corrected by reshaping the c parameter. 
