### PR TITLE
bugfix in CorrelateRMS

### DIFF
--- a/wmpl/Trajectory/CorrelateRMS.py
+++ b/wmpl/Trajectory/CorrelateRMS.py
@@ -878,6 +878,10 @@ class RMSDataHandle(object):
             traj_dir_path: [str] Full path to a directory with trajectory pickles.
         """
 
+        # defend against the case where there are no existing trajectories and traj_dir_path doesn't exist
+        if not os.path.isdir(traj_dir_path):
+            return
+        
         print("  Loading trajectories from:", traj_dir_path)
         print("  Datetime range:", self.dt_range)
 


### PR DESCRIPTION
in loadComputedTrajectories() the code will crash if there are no existing trajectories and thus traj_dir_path does not exist. This condition can arise on a brand-new installation or simply if there had been no solutions previously created in the sample period.