### PR TITLE
Performance improvement to CorrelateRMS

### DIFF
--- a/wmpl/Trajectory/CorrelateEngine.py
+++ b/wmpl/Trajectory/CorrelateEngine.py
@@ -1104,7 +1104,7 @@ class TrajectoryCorrelator(object):
             else:
                 dt_beg = unpaired_observations_all[0].reference_dt
                 dt_end = unpaired_observations_all[-1].reference_dt
-                dt_bin_list = generateDatetimeBins(dt_beg, dt_end, bin_days=1, utc_hour_break=12, tzinfo=datetime.timezone.utc)
+                dt_bin_list = generateDatetimeBins(dt_beg, dt_end, bin_days=1, utc_hour_break=12, tzinfo=datetime.timezone.utc, reverse=True)
         else:
             dt_beg = self.dh.dt_range[0]
             dt_end = self.dh.dt_range[1]

--- a/wmpl/Trajectory/CorrelateRMS.py
+++ b/wmpl/Trajectory/CorrelateRMS.py
@@ -1644,7 +1644,7 @@ contain data folders. Data folders should have FTPdetectinfo files together with
     arg_parser.add_argument('--mcmode', '--mcmode', type=int, default=0,
         help="Run just simple soln (1), just monte-carlos (2) or both (0, default).")
 
-    arg_parser.add_argument('--maxtrajs', '--maxtrajs', type=int, default=1000,
+    arg_parser.add_argument('--maxtrajs', '--maxtrajs', type=int, default=None,
         help="Max number of trajectories to reload in each pass when doing the Monte-Carlo phase")
     
     arg_parser.add_argument('--autofreq', '--autofreq', type=int, default=360,

--- a/wmpl/Trajectory/CorrelateRMS.py
+++ b/wmpl/Trajectory/CorrelateRMS.py
@@ -215,9 +215,9 @@ class DatabaseJSON(object):
                 os.remove(db_bak_file_path)
 
         except Exception as e:
-            log.warning(f'unable to save the database, likely corrupt data')
+            log.warning('unable to save the database, likely corrupt data')
             shutil.copy2(db_bak_file_path, self.db_file_path)
-            log.warning('e')
+            log.warning(e)
 
     def addProcessedDir(self, station_name, rel_proc_path):
         """ Add the processed directory to the list. """

--- a/wmpl/Trajectory/CorrelateRMS.py
+++ b/wmpl/Trajectory/CorrelateRMS.py
@@ -1848,8 +1848,7 @@ contain data folders. Data folders should have FTPdetectinfo files together with
                 proc_dir_dt_beg = min(proc_dir_dts)
                 proc_dir_dt_end = max(proc_dir_dts)
                 # Split the processing into daily chunks
-                dt_bins = generateDatetimeBins(proc_dir_dt_beg, proc_dir_dt_end, bin_days=1, 
-                                            tzinfo=datetime.timezone.utc)
+                dt_bins = generateDatetimeBins(proc_dir_dt_beg, proc_dir_dt_end, bin_days=1, tzinfo=datetime.timezone.utc, reverse=True)
 
                 # check if we've created an extra bucket (might happen if requested timeperiod is less than 24h)
                 if event_time_range is not None:

--- a/wmpl/Trajectory/CorrelateRMS.py
+++ b/wmpl/Trajectory/CorrelateRMS.py
@@ -321,7 +321,7 @@ class DatabaseJSON(object):
 
 
 
-    def removeTrajectory(self, traj_reduced):
+    def removeTrajectory(self, traj_reduced, keepFolder=False):
         """ Remove the trajectory from the data base and disk. """
 
         # Remove the trajectory data base entry
@@ -329,9 +329,9 @@ class DatabaseJSON(object):
             del self.trajectories[traj_reduced.jdt_ref]
 
         # Remove the trajectory folder on the disk
-        if os.path.isfile(traj_reduced.traj_file_path):
-
+        if not keepFolder and os.path.isfile(traj_reduced.traj_file_path):
             traj_dir = os.path.dirname(traj_reduced.traj_file_path)
+            log.info(f'removing {traj_dir}')
             shutil.rmtree(traj_dir)
 
 
@@ -625,12 +625,12 @@ class RMSDataHandle(object):
         for traj in [t for t in self.db.trajectories if t < archdate_jd]:
             if traj < archdate_jd:
                 archdb.addTrajectory(None, self.db.trajectories[traj], False)
-                self.db.removeTrajectory(self.db.trajectories[traj])
+                self.db.removeTrajectory(self.db.trajectories[traj], keepFolder=True)
 
         for traj in [t for t in self.db.failed_trajectories if t < archdate_jd]:
             if traj < archdate_jd:
                 archdb.addTrajectory(None, self.db.failed_trajectories[traj], True)
-                self.db.removeTrajectory(self.db.failed_trajectories[traj])
+                self.db.removeTrajectory(self.db.failed_trajectories[traj], keepFolder=True)
 
         for station in self.db.processed_dirs:
             arch_processed = [dirname for dirname in self.db.processed_dirs[station] if 
@@ -1394,7 +1394,7 @@ class RMSDataHandle(object):
         the pickle, because we might later on get new data and it might become solvable. Otherwise, we can just delete the file 
         since the MC solver will have saved an updated one already.
         """
-        if not self.mc_mode != 2:
+        if self.mc_mode != 2:
             return 
         fldr_name = os.path.split(self.generateTrajOutputDirectoryPath(traj, make_dirs=False))[-1] 
         pick = os.path.join(self.phase1_dir, fldr_name + '_trajectory.pickle_processing')
@@ -1803,6 +1803,11 @@ contain data folders. Data folders should have FTPdetectinfo files together with
                 log.info("    END: {:s}".format(str(dt_end)))
 
                 event_time_range = [dt_beg, dt_end]
+            else:
+                # set the timerange to cover all possible dates
+                dt_beg = datetime.datetime(2000,1,1,0,0,0).replace(tzinfo=datetime.timezone.utc)
+                dt_end = datetime.datetime.now().replace(tzinfo=datetime.timezone.utc)
+                event_time_range = [dt_beg, dt_end]
 
         # Init the data handle
         dh = RMSDataHandle(
@@ -1845,7 +1850,7 @@ contain data folders. Data folders should have FTPdetectinfo files together with
                 # Split the processing into daily chunks
                 dt_bins = generateDatetimeBins(proc_dir_dt_beg, proc_dir_dt_end, bin_days=1, 
                                             tzinfo=datetime.timezone.utc)
-                
+
                 # check if we've created an extra bucket (might happen if requested timeperiod is less than 24h)
                 if event_time_range is not None:
                     if dt_bins[-1][0] > event_time_range[1]: 

--- a/wmpl/Utils/Math.py
+++ b/wmpl/Utils/Math.py
@@ -5,7 +5,6 @@
 from __future__ import division, print_function, absolute_import
 
 import datetime
-import pytz
 
 import numpy as np
 import scipy.linalg
@@ -53,6 +52,7 @@ def vectNorm(vect):
     """Convert a given vector to a unit vector."""
 
     return vect/vectMag(vect)
+
 
 @njit
 def vectMag(vect):
@@ -353,8 +353,7 @@ def angleBetweenSphericalCoords(phi1, lambda1, phi2, lambda2):
     """
 
     # Compute the cosine of the angle
-    cos_angle = (np.sin(phi1)*np.sin(phi2) +
-                 np.cos(phi1)*np.cos(phi2)*np.cos(lambda2 - lambda1))
+    cos_angle = (np.sin(phi1)*np.sin(phi2) + np.cos(phi1)*np.cos(phi2)*np.cos(lambda2 - lambda1))
 
     # Clamp the value to the valid range of arccos
     cos_angle = np.clip(cos_angle, -1.0, 1.0)
@@ -849,13 +848,13 @@ def mergeClosePoints(x_array, y_array, delta, x_datetime=False, method="avg"):
 
             # Choose either to take the mean, max, or min of the points in the window
             if method.lower() == "max":
-                y = np.max(y_array[i : i + count])
+                y = np.max(y_array[i: i + count])
 
             elif method.lower() == "min":
-                y = np.min(y_array[i : i + count])
+                y = np.min(y_array[i: i + count])
 
             else:
-                y = np.mean(y_array[i : i + count])
+                y = np.mean(y_array[i: i + count])
 
         # If there are no close points, add the current point to the list
         else:
@@ -885,7 +884,7 @@ def movingAverage(arr, n=3):
 
     ret[n:] = ret[n:] - ret[:-n]
 
-    return ret[n - 1 :] / n
+    return ret[n - 1:] / n
 
 
 def subsampleAverage(arr, n=3):
@@ -961,7 +960,7 @@ def checkContinuity(sequence):
         # Check if that continous sequence is a sequence of ones, or a sequence of zeros
         first, last = np.argwhere(diffs != 0)
 
-        if np.count_nonzero(sequence[first[0] + 1 : last[0]] == 1):
+        if np.count_nonzero(sequence[first[0] + 1: last[0]] == 1):
             return True, first[0] + 1, last[0]
 
     return False, 0, 0
@@ -1077,7 +1076,7 @@ def fitConfidenceInterval(x_data, y_data, conf=0.95, x_array=None, func=None):
 ##############################################################################################################
 
 
-def generateDatetimeBins(dt_beg, dt_end, bin_days=7, utc_hour_break=12, tzinfo=None):
+def generateDatetimeBins(dt_beg, dt_end, bin_days=7, utc_hour_break=12, tzinfo=None, reverse=False):
     """Given a beginning and end datetime, bin this time range into bins bin_days long. The bin edges will
         be at utc_hour_break UTC. 12:00 UTC is chosen because at that time it is midnight at the International
         Date Line, and it is very unlikely that there are any meteor cameras there.
@@ -1131,6 +1130,9 @@ def generateDatetimeBins(dt_beg, dt_end, bin_days=7, utc_hour_break=12, tzinfo=N
         # Stop iterating if the end was reached
         if end_reached:
             break
+
+    if reverse:
+        time_bins.reverse()
 
     return time_bins
 
@@ -1243,7 +1245,7 @@ if __name__ == "__main__":
     sys.exit()
 
     # Test hull functions
-    from mpl_toolkits.mplot3d import Axes3D
+    #from mpl_toolkits.mplot3d import Axes3D
     import matplotlib.pyplot as plt
 
     # Define hull points

--- a/wmpl/Utils/remoteDataHandling.py
+++ b/wmpl/Utils/remoteDataHandling.py
@@ -42,7 +42,7 @@ def collectRemoteTrajectories(remotehost, max_trajs, output_dir):
     if ftpcli is None:
         return 
     remote_phase1_dir = os.path.join(remote_dir, 'phase1').replace('\\','/')
-    log.info(f'Looking in {remote_phase1_dir} on remote host')
+    log.info(f'Looking in {remote_phase1_dir} on remote host for up to {max_trajs} trajectories')
     try:
         files = ftpcli.listdir(remote_phase1_dir)
         files = [f for f in files if '.pickle' in f and 'processing' not in f]


### PR DESCRIPTION
In auto mode, iterate over the time buckets in reverse order so the most recent data is processed first. This ensures last night's trajectories are calculated quickly, and then any new or changed trajectories from previous nights are updated if needed. This improved performance on the test server from ~3.5 hours to about 1.5 hours though centaurid is slower than hydrid2 so i'd not expect quite such a big improvement there.

Also a couple of bugfixes:
- avoid purging older trajectories if they're not in the json database any more. This bug crept in because we now archive off older data from the traj db
- in mcmode 0, if no date range is supplied, process all available data. This was the previous default behaviour, inadvertently changed by an earlier bugfix. 
- some syntax tidying up, removing unnecessary spaces and so forth