### PR TITLE
A set of fixes to remove duplicate transactions and slightly improve performance

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,23 +147,23 @@ If you are getting the following error on Windows: ```Unable to find vcvarsall.b
 If you are getting this error when running the setup: ```ModuleNotFoundError: No module named 'wmpl.PythonNRLMSISE00.nrlmsise_00_header'```, it means that you haven't cloned the repository as per instructions. Please read this README file more carefully (hint: the answer is at the top of the file).
 
 ##### ```KeyError: 'PROJ_LIB'```
-The basemap conda package is terribly broken and no one seems to care to fix it, so we have to do a little bit of "hacking". First, find where your anaconda is installed. 
+The basemap conda package is terribly broken and no one seems to care to fix it, so we have to do a little bit of "hacking". 
 
-Under Windows, it is probably in ```C:\Users\<YOUR_USERNAME>\AppData\Local\Continuum\anaconda3\``` or ```C:\Users\<YOUR_USERNAME>\Anaconda3\```, where you should replace <YOUR_USERNAME> with your username (duh!). From now on I will refer to this path as ```<ANACONDA_DIR>```. 
+First, find where your anaconda is installed. Under Windows, it is probably in ```C:\Users\<YOUR_USERNAME>\AppData\Local\Continuum\anaconda3\``` or ```C:\Users\<YOUR_USERNAME>\Anaconda3\```, where you should replace <YOUR_USERNAME> with your username (duh!). From now on I will refer to this path as ```<ANACONDA_DIR>```. 
 
-Look in the pkgs directory. You should find a folder named something like ```proj-9.5.1-h4f671f6_0```. The exact details vary and you may have more than one version installed. Make a note of the name of the newest one. I will refer to this as ```<PROJDIR>```
+In this folder, look in the ```pkgs``` folder. You should find a folder named something like ```proj-9.5.1-h4f671f6_0```. The exact details vary and you may have more than one version installed. Make a note of the name of the newest one. I will refer to this as ```<PROJDIR>```
 
 Now, create a new Environment Variable. Note the differences between Windows and Linux.
 
-Windows: ```<ANACONDA_DIR>\pkgs\<PROJDIR>\Library\share\proj\```. 
-Linux:   ```<ANACONDA_DIR>/pkgs/<PROJDIR>/share/proj/```. 
+Windows: ```<ANACONDA_DIR>\pkgs\<PROJDIR>\Library\share\proj\```
+Linux:   ```<ANACONDA_DIR>/pkgs/<PROJDIR>/share/proj/```
 
 For example on my Windows PC, the location is 
 ```C:\Users\Mark\miniconda3\pkgs\proj-9.5.1-h4f671f6_0\Library\share\proj\```
 and on my Linux server it is 
 ```$HOME/miniconda3/pkgs/proj-9.3.1-he5811b7_0/share/proj```
 
-Restart any termina, CMD or Powershell windows, and you should find that the error has been resolved.  If not, try one of the other versions of proj thats probably in your pkgs folder. 
+Restart any terminal, CMD or Powershell windows, and you should find that the error has been resolved.  If not, try one of the other versions of proj thats probably in your pkgs folder. 
 
 ##### Missing epsg file
 If you get this error:

--- a/README.md
+++ b/README.md
@@ -142,32 +142,31 @@ If you experience any issues, please see the "Troubleshooting" section below.
 
 #### Troubleshooting
 
-If you are getting the following error on Windows: ```Unable to find vcvarsall.bat```, that means you need to install [Visual C++ Build Tools 2015](http://go.microsoft.com/fwlink/?LinkId=691126).
+If you are getting the following error on Windows: ```Unable to find vcvarsall.bat```, that means you need to install [Visual C++ Build Tools 2015](http://go.microsoft.com/fwlink/?LinkId=691126) or 2022. 
 
 If you are getting this error when running the setup: ```ModuleNotFoundError: No module named 'wmpl.PythonNRLMSISE00.nrlmsise_00_header'```, it means that you haven't cloned the repository as per instructions. Please read this README file more carefully (hint: the answer is at the top of the file).
 
 ##### ```KeyError: 'PROJ_LIB'```
 The basemap conda package is terribly broken and no one seems to care to fix it, so we have to do a little bit of "hacking". First, find where your anaconda is installed. 
 
-Under Windows, it is probably in ```C:\Users\<YOUR_USERNAME>\AppData\Local\Continuum\anaconda3\``` or ```C:\Users\<YOUR_USERNAME>\Anaconda3\```, where you should replace <YOUR_USERNAME> with your username (duh!). From now on I will refer to this path as ```<ANACONDA_DIR>```.
-Open the following file in a text editor: ```<ANACONDA_DIR>\envs\wmpl\Lib\site-packages\mpl_toolkits\basemap\__init__.py```. 
+Under Windows, it is probably in ```C:\Users\<YOUR_USERNAME>\AppData\Local\Continuum\anaconda3\``` or ```C:\Users\<YOUR_USERNAME>\Anaconda3\```, where you should replace <YOUR_USERNAME> with your username (duh!). From now on I will refer to this path as ```<ANACONDA_DIR>```. 
 
-Under Linux, it is probably in ```/home/<YOUR_USERNAME>/anaconda3```. From now on I will refer to this path as ```<ANACONDA_DIR>```. Open the following file in a text editor: ```<ANACONDA_DIR>/envs/wmpl/lib/python3.7/site-packages/mpl_toolkits/basemap/__init__.py```. 
+Look in the pkgs directory. You should find a folder named something like ```proj-9.5.1-h4f671f6_0```. The exact details vary and you may have more than one version installed. Make a note of the name of the newest one. I will refer to this as ```<PROJDIR>```
 
-Find the line ```pyproj_datadir = os.environ['PROJ_LIB']```, and comment it out by putting a # in front of it. Right below that command, add the following line(for Windows):
-```
-pyproj_datadir = "<ANACONDA_DIR>/envs/wmpl/Library/share"
-```
-(for Linux):
-```
-pyproj_datadir = "<ANACONDA_DIR>/envs/wmpl/share/basemap"
-```
+Now, create a new Environment Variable. Note the differences between Windows and Linux.
 
-Just make sure to replace <ANACONDA_DIR> with the full path. Also, make sure to replace all backslashes ```\``` with forward slashes ```/``` in the path.
+Windows: ```<ANACONDA_DIR>\pkgs\<PROJDIR>\Library\share\proj\```. 
+Linux:   ```<ANACONDA_DIR>/pkgs/<PROJDIR>/share/proj/```. 
 
-Save the file. Enjoy.
+For example on my Windows PC, the location is 
+```C:\Users\Mark\miniconda3\pkgs\proj-9.5.1-h4f671f6_0\Library\share\proj\```
+and on my Linux server it is 
+```$HOME/miniconda3/pkgs/proj-9.3.1-he5811b7_0/share/proj```
 
-If after this you get this error:
+Restart any termina, CMD or Powershell windows, and you should find that the error has been resolved.  If not, try one of the other versions of proj thats probably in your pkgs folder. 
+
+##### Missing epsg file
+If you get this error:
 
 ```FileNotFoundError: [Errno 2] No such file or directory: '<ANACONDA_DIR>/envs/wmpl/Library/share\\epsg'```
 

--- a/wmpl/Trajectory/AggregateAndPlot.py
+++ b/wmpl/Trajectory/AggregateAndPlot.py
@@ -1736,6 +1736,9 @@ def loadTrajectoryPickles(dir_path, traj_quality_params, time_beg=None, time_end
                 traj_list.append(traj)
 
     # Sort trajectories by time
+    if verbose:
+        print(f"Loaded {loaded_trajs_count} trajectories...")
+        print(f'of which {loaded_trajs_count - len(traj_list)} were rejected')
     traj_list = sorted(traj_list, key=lambda x: x.jdt_ref)
 
     # Remove duplicate trajectories

--- a/wmpl/Trajectory/CorrelateEngine.py
+++ b/wmpl/Trajectory/CorrelateEngine.py
@@ -1109,7 +1109,7 @@ class TrajectoryCorrelator(object):
                 dt_bin_list = generateDatetimeBins(
                     dt_beg, dt_end, 
                     bin_days=1, utc_hour_break=12, tzinfo=datetime.timezone.utc, reverse=False
-                    )
+                )
                 
         else:
             dt_beg = self.dh.dt_range[0]

--- a/wmpl/Trajectory/CorrelateEngine.py
+++ b/wmpl/Trajectory/CorrelateEngine.py
@@ -1031,7 +1031,7 @@ class TrajectoryCorrelator(object):
                 traj.phase_1_only = True
 
             if orig_traj:
-                log.info("Removing the previous solution...")
+                log.info(f"Removing the previous solution {os.path.dirname(orig_traj.traj_file_path)} ...")
                 self.dh.removeTrajectory(orig_traj)
                 traj.pre_mc_longname = os.path.split(self.dh.generateTrajOutputDirectoryPath(orig_traj, make_dirs=False))[-1] 
 

--- a/wmpl/Trajectory/CorrelateEngine.py
+++ b/wmpl/Trajectory/CorrelateEngine.py
@@ -1724,11 +1724,9 @@ class TrajectoryCorrelator(object):
             # end of "for matched_observations in candidate_trajectories"
             outcomes = [traj_solved_count]
 
+            # Finish the correlation run (update the database with new values)
             self.dh.saveDatabase()
             log.info(f'SOLVED {sum(outcomes)} TRAJECTORIES')
-
-            # Finish the correlation run (update the database with new values)
-            self.dh.finish()
 
             log.info("")
             log.info("-----------------")

--- a/wmpl/Trajectory/CorrelateRMS.py
+++ b/wmpl/Trajectory/CorrelateRMS.py
@@ -1180,7 +1180,7 @@ class RMSDataHandle(object):
                     traj_file_name = os.path.split(traj.traj_file_path)[1]
                     traj.traj_file_path = os.path.join(traj_path, traj_file_name)
                     log.info(f'removing duplicate {traj.traj_id} keep {traj.traj_file_path} {keepFolder}')
-                    #self.db.removeTrajectory(traj, keepFolder=keepFolder)
+                    self.db.removeTrajectory(traj, keepFolder=keepFolder)
                 else:
                     log.info(f'keeping {traj.traj_id} {traj.traj_file_path}')
          

--- a/wmpl/Trajectory/CorrelateRMS.py
+++ b/wmpl/Trajectory/CorrelateRMS.py
@@ -1030,7 +1030,8 @@ class RMSDataHandle(object):
         keys = [k for k in self.db.trajectories.keys() if k >= jdt_start and k <= jdt_end]
         for trajkey in keys:
             traj_reduced = self.db.trajectories[trajkey]
-            traj_path = os.path.join(self.output_dir, traj_reduced.traj_file_path)
+            # Update the trajectory path to make sure we're working with the correct filesystem
+            traj_path = self.generateTrajOutputDirectoryPath(traj_reduced)
             log.info(f' testing {traj_path}')
             if not os.path.isfile(traj_path):
                 trajs_to_remove.append(traj_reduced)

--- a/wmpl/Trajectory/CorrelateRMS.py
+++ b/wmpl/Trajectory/CorrelateRMS.py
@@ -1143,7 +1143,9 @@ class RMSDataHandle(object):
         
         tr_in_scope = self.getComputedTrajectories(datetime2JD(dt_range[0]), datetime2JD(dt_range[1]))
         tr_to_check = [{'jdt_ref':traj.jdt_ref,'traj_id':traj.traj_id, 'traj': traj} for traj in tr_in_scope if hasattr(traj,'traj_id')]
-        
+        if len(tr_to_check) ==0:
+            log.info('no trajectories in range')
+            return 
         tr_df = pd.DataFrame(tr_to_check)
         tr_df['dupe']=tr_df.duplicated(subset=['traj_id'])
         dupeids = tr_df[tr_df.dupe].sort_values(by=['traj_id']).traj_id

--- a/wmpl/Trajectory/CorrelateRMS.py
+++ b/wmpl/Trajectory/CorrelateRMS.py
@@ -161,10 +161,8 @@ class DatabaseJSON(object):
         #   TrajectoryReduced objects)
         self.failed_trajectories = {}
 
-        self.verbose = False
-        if verbose:
-            self.verbose = True
-        print(f'self.verbose is {self.verbose} here')
+        self.verbose = verbose
+        print(f'self.verbose is {self.verbose} during init')
 
         # Load the database from a JSON file
         self.load()
@@ -560,7 +558,6 @@ class RMSDataHandle(object):
         if mcmode != 2:
             log.info("Loading database: {:s}".format(database_path))
             self.db = DatabaseJSON(database_path, verbose=self.verbose)
-            print(f'self.db.verbose is {self.db.verbose}')
             log.info('Archiving older entries....')
             try:
                 self.archiveOldRecords(older_than=3)

--- a/wmpl/Trajectory/CorrelateRMS.py
+++ b/wmpl/Trajectory/CorrelateRMS.py
@@ -1984,7 +1984,8 @@ contain data folders. Data folders should have FTPdetectinfo files together with
                     # refresh list of calculated trajectories from disk
                     dh.removeDeletedTrajectories()
                     dh.loadComputedTrajectories(os.path.join(dh.output_dir, OUTPUT_TRAJ_DIR), dt_range=[bin_beg, bin_end])
-                    dh.removeDuplicateTrajectories(dt_range=[bin_beg, bin_end])
+                    if cml_args.mcmode != 2:
+                        dh.removeDuplicateTrajectories(dt_range=[bin_beg, bin_end])
 
                     # Run the trajectory correlator
                     tc = TrajectoryCorrelator(dh, trajectory_constraints, cml_args.velpart, data_in_j2000=True, enableOSM=cml_args.enableOSM)

--- a/wmpl/Trajectory/CorrelateRMS.py
+++ b/wmpl/Trajectory/CorrelateRMS.py
@@ -299,7 +299,8 @@ class DatabaseJSON(object):
 
             # Init the reduced trajectory object
             traj_reduced = TrajectoryReduced(traj_file_path)
-            log.info(f' loaded {traj_file_path}, traj_id {traj_reduced.traj_id}')
+            if self.verbose:
+                log.info(f' loaded {traj_file_path}, traj_id {traj_reduced.traj_id}')
             # Skip if failed
             if traj_reduced is None:
                 return None

--- a/wmpl/Trajectory/CorrelateRMS.py
+++ b/wmpl/Trajectory/CorrelateRMS.py
@@ -1031,11 +1031,12 @@ class RMSDataHandle(object):
         for trajkey in keys:
             traj_reduced = self.db.trajectories[trajkey]
             traj_path = os.path.join(self.output_dir, traj_reduced.traj_file_path)
+            log.info(f' testing {traj_path}')
             if not os.path.isfile(traj_path):
                 trajs_to_remove.append(traj_reduced)
         for traj in trajs_to_remove:
             log.info(f' removing deleted {traj.traj_file_path}')
-            self.db.removeTrajectory(traj)
+            self.db.removeTrajectory(traj, True)
         #self.saveDatabase()
         return 
 
@@ -1151,7 +1152,7 @@ class RMSDataHandle(object):
         dupeids = tr_df[tr_df.dupe].sort_values(by=['traj_id']).traj_id
         duperows = tr_df[tr_df.traj_id.isin(dupeids)]
 
-        log.info(f'there are {int(len(duperows)/2)} duplicate trajectories')
+        log.info(f'there are {duperows} duplicate trajectories')
 
         
         # iterate over the duplicates, finding the best and removing the others

--- a/wmpl/Trajectory/CorrelateRMS.py
+++ b/wmpl/Trajectory/CorrelateRMS.py
@@ -557,6 +557,7 @@ class RMSDataHandle(object):
         if mcmode != 2:
             log.info("Loading database: {:s}".format(database_path))
             self.db = DatabaseJSON(database_path, verbose=self.verbose)
+            print(f'self.db.verbose is {self.db.verbose}')
             log.info('Archiving older entries....')
             try:
                 self.archiveOldRecords(older_than=3)

--- a/wmpl/Trajectory/CorrelateRMS.py
+++ b/wmpl/Trajectory/CorrelateRMS.py
@@ -141,7 +141,7 @@ class TrajectoryReduced(object):
 
 
 class DatabaseJSON(object):
-    def __init__(self, db_file_path):
+    def __init__(self, db_file_path, verbose=False):
 
         self.db_file_path = db_file_path
 
@@ -160,6 +160,8 @@ class DatabaseJSON(object):
         # List of failed trajectories (keys are trajectory reference julian dates, values are \
         #   TrajectoryReduced objects)
         self.failed_trajectories = {}
+
+        self.verbose = verbose
 
         # Load the database from a JSON file
         self.load()
@@ -308,7 +310,8 @@ class DatabaseJSON(object):
         else:
             # Use the provided trajectory object
             traj_reduced = traj_obj
-            log.info(f' loaded {traj_obj.traj_file_path}, traj_id {traj_reduced.traj_id}')
+            if self.verbose:
+                log.info(f' loaded {traj_obj.traj_file_path}, traj_id {traj_reduced.traj_id}')
 
 
         # Choose to which dictionary the trajectory will be added
@@ -551,7 +554,7 @@ class RMSDataHandle(object):
 
         if mcmode != 2:
             log.info("Loading database: {:s}".format(database_path))
-            self.db = DatabaseJSON(database_path)
+            self.db = DatabaseJSON(database_path, verbose=self.verbose)
             log.info('Archiving older entries....')
             try:
                 self.archiveOldRecords(older_than=3)
@@ -625,7 +628,7 @@ class RMSDataHandle(object):
         archdate_jd = datetime2JD(archdate)
 
         arch_db_path = os.path.join(self.db_dir, f'{archdate.strftime("%Y%m")}_{JSON_DB_NAME}')
-        archdb = DatabaseJSON(arch_db_path)
+        archdb = DatabaseJSON(arch_db_path, verbose=self.verbose)
         log.info(f'Archiving db records to {arch_db_path}...')
 
         for traj in [t for t in self.db.trajectories if t < archdate_jd]:

--- a/wmpl/Trajectory/CorrelateRMS.py
+++ b/wmpl/Trajectory/CorrelateRMS.py
@@ -161,16 +161,11 @@ class DatabaseJSON(object):
         #   TrajectoryReduced objects)
         self.failed_trajectories = {}
 
-        self.verbose = verbose
-        print(f'self.verbose is {self.verbose} during init')
-
-        self.potato=True
-
         # Load the database from a JSON file
-        self.load()
+        self.load(verbose=verbose)
 
 
-    def load(self):
+    def load(self, verbose=False):
         """ Load the database from a JSON file. """
 
         if os.path.exists(self.db_file_path):
@@ -195,8 +190,9 @@ class DatabaseJSON(object):
 
                     # Set the trajectory dictionary
                     setattr(self, traj_dict_str, trajectories_obj_dict)
-        print(f'self.potato is {self.potato} here')
-        print(f'self.verbose is {self.verbose} here')
+
+        # do this here because the object dict is overwritten during the load operation above
+        self.verbose = verbose
 
 
     def save(self):

--- a/wmpl/Trajectory/CorrelateRMS.py
+++ b/wmpl/Trajectory/CorrelateRMS.py
@@ -337,10 +337,9 @@ class DatabaseJSON(object):
         # Remove the trajectory folder on the disk
         if not keepFolder and os.path.isfile(traj_reduced.traj_file_path):
             traj_dir = os.path.dirname(traj_reduced.traj_file_path)
-            log.info(f'removing {traj_dir}')
             shutil.rmtree(traj_dir, ignore_errors=True)
-        if os.path.isfile(traj_reduced.traj_file_path):
-            log.info(f'unable to remove {traj_dir}')
+            if os.path.isfile(traj_reduced.traj_file_path):
+                log.info(f'unable to remove {traj_dir}')
 
 
 
@@ -1033,9 +1032,9 @@ class RMSDataHandle(object):
             traj_reduced = self.db.trajectories[trajkey]
             traj_path = os.path.join(self.output_dir, traj_reduced.traj_file_path)
             if not os.path.isfile(traj_path):
-                log.info(f' removing {traj_reduced.traj_file_path}')
                 trajs_to_remove.append(traj_reduced)
         for traj in trajs_to_remove:
+            log.info(f' removing deleted {traj.traj_file_path}')
             self.db.removeTrajectory(traj)
         #self.saveDatabase()
         return 
@@ -1169,8 +1168,8 @@ class RMSDataHandle(object):
                     traj_path = self.generateTrajOutputDirectoryPath(traj)
                     traj_file_name = os.path.split(traj.traj_file_path)[1]
                     traj.traj_file_path = os.path.join(traj_path, traj_file_name)
-                    print(f'removing {traj.traj_file_path}')
-                    #self.db.removeTrajectory(traj)
+                    log.info(f'removing duplicate {traj.traj_file_path}')
+                    self.db.removeTrajectory(traj)
          
         return 
     

--- a/wmpl/Trajectory/CorrelateRMS.py
+++ b/wmpl/Trajectory/CorrelateRMS.py
@@ -1168,8 +1168,8 @@ class RMSDataHandle(object):
 
             # now remove all except the best
             for testdt in duperows[duperows.traj_id==traj_id].jdt_ref.values:
+                traj = dh.db.trajectories[testdt]
                 if testdt != best_traj_dt:
-                    traj = dh.db.trajectories[testdt]
                     # get the current trajectory's location. If its the same as that of the best trajectory
                     # don't try to delete the solution from disk even if there's a small difference in jdt_ref
                     keepFolder = False

--- a/wmpl/Trajectory/CorrelateRMS.py
+++ b/wmpl/Trajectory/CorrelateRMS.py
@@ -1149,9 +1149,11 @@ class RMSDataHandle(object):
         duperows = tr_df[tr_df.traj_id.isin(dupeids)]
 
         log.info(f'there are {int(len(duperows)/2)} duplicate trajectories')
+
         
         # iterate over the duplicates, finding the best and removing the others
         for traj_id in duperows.traj_id.unique():
+            print(traj_id, duperows[duperows.traj_id==traj_id].traj_file_path)
             num_stats = 0
             best_traj_dt = None
             # find duplicate with largest number of observations
@@ -1169,7 +1171,7 @@ class RMSDataHandle(object):
                     traj_file_name = os.path.split(traj.traj_file_path)[1]
                     traj.traj_file_path = os.path.join(traj_path, traj_file_name)
                     log.info(f'removing duplicate {traj.traj_file_path}')
-                    self.db.removeTrajectory(traj)
+                    #self.db.removeTrajectory(traj)
          
         return 
     

--- a/wmpl/Trajectory/CorrelateRMS.py
+++ b/wmpl/Trajectory/CorrelateRMS.py
@@ -161,7 +161,9 @@ class DatabaseJSON(object):
         #   TrajectoryReduced objects)
         self.failed_trajectories = {}
 
-        self.verbose = verbose
+        self.verbose = False
+        if verbose:
+            self.verbose = True
         print(f'self.verbose is {self.verbose}')
 
         # Load the database from a JSON file

--- a/wmpl/Trajectory/CorrelateRMS.py
+++ b/wmpl/Trajectory/CorrelateRMS.py
@@ -162,6 +162,7 @@ class DatabaseJSON(object):
         self.failed_trajectories = {}
 
         self.verbose = verbose
+        print(f'self.verbose is {self.verbose}')
 
         # Load the database from a JSON file
         self.load()

--- a/wmpl/Trajectory/CorrelateRMS.py
+++ b/wmpl/Trajectory/CorrelateRMS.py
@@ -164,7 +164,7 @@ class DatabaseJSON(object):
         self.verbose = False
         if verbose:
             self.verbose = True
-        print(f'self.verbose is {self.verbose}')
+        print(f'self.verbose is {self.verbose} here')
 
         # Load the database from a JSON file
         self.load()
@@ -195,6 +195,7 @@ class DatabaseJSON(object):
 
                     # Set the trajectory dictionary
                     setattr(self, traj_dict_str, trajectories_obj_dict)
+        print(f'self.verbose is {self.verbose} here')
 
 
     def save(self):

--- a/wmpl/Trajectory/CorrelateRMS.py
+++ b/wmpl/Trajectory/CorrelateRMS.py
@@ -1630,18 +1630,6 @@ class RMSDataHandle(object):
         # Restore the signal functionality
         signal.signal(signal.SIGINT, original_signal)
 
-
-
-
-
-    def finish(self):
-        """ Finish the processing run. """
-
-        # Save the processed directories to the DB file
-        self.saveDatabase()
-
-        # Save the list of processed meteor observations
-
         
 
 

--- a/wmpl/Trajectory/CorrelateRMS.py
+++ b/wmpl/Trajectory/CorrelateRMS.py
@@ -1032,11 +1032,16 @@ class RMSDataHandle(object):
             traj_reduced = self.db.trajectories[trajkey]
             # Update the trajectory path to make sure we're working with the correct filesystem
             traj_path = self.generateTrajOutputDirectoryPath(traj_reduced)
+            traj_file_name = os.path.split(traj_reduced.traj_file_path)[1]
+            traj_path = os.path.join(traj_path, traj_file_name)
             log.info(f' testing {traj_path}')
             if not os.path.isfile(traj_path):
+                traj_reduced.traj_file_path = traj_path
                 trajs_to_remove.append(traj_reduced)
         for traj in trajs_to_remove:
             log.info(f' removing deleted {traj.traj_file_path}')
+            # remove from the database but not from the disk: they're already not on the disk and this avoids
+            # accidentally deleting a different traj with a timestamp which is within a millisecond
             self.db.removeTrajectory(traj, True)
         #self.saveDatabase()
         return 
@@ -1153,7 +1158,7 @@ class RMSDataHandle(object):
         dupeids = tr_df[tr_df.dupe].sort_values(by=['traj_id']).traj_id
         duperows = tr_df[tr_df.traj_id.isin(dupeids)]
 
-        log.info(f'there are {duperows} duplicate trajectories')
+        log.info(f'there are {len(duperows.traj_id.unique())} duplicate trajectories')
 
         
         # iterate over the duplicates, finding the best and removing the others

--- a/wmpl/Trajectory/CorrelateRMS.py
+++ b/wmpl/Trajectory/CorrelateRMS.py
@@ -164,6 +164,8 @@ class DatabaseJSON(object):
         self.verbose = verbose
         print(f'self.verbose is {self.verbose} during init')
 
+        self.potato=True
+
         # Load the database from a JSON file
         self.load()
 
@@ -193,6 +195,7 @@ class DatabaseJSON(object):
 
                     # Set the trajectory dictionary
                     setattr(self, traj_dict_str, trajectories_obj_dict)
+        print(f'self.potato is {self.potato} here')
         print(f'self.verbose is {self.verbose} here')
 
 

--- a/wmpl/Trajectory/CorrelateRMS.py
+++ b/wmpl/Trajectory/CorrelateRMS.py
@@ -1153,7 +1153,6 @@ class RMSDataHandle(object):
         
         # iterate over the duplicates, finding the best and removing the others
         for traj_id in duperows.traj_id.unique():
-            print(traj_id, duperows[duperows.traj_id==traj_id].traj_file_path)
             num_stats = 0
             best_traj_dt = None
             # find duplicate with largest number of observations
@@ -1170,8 +1169,10 @@ class RMSDataHandle(object):
                     traj_path = self.generateTrajOutputDirectoryPath(traj)
                     traj_file_name = os.path.split(traj.traj_file_path)[1]
                     traj.traj_file_path = os.path.join(traj_path, traj_file_name)
-                    log.info(f'removing duplicate {traj.traj_file_path}')
+                    log.info(f'removing duplicate {traj.traj_id} {traj.traj_file_path}')
                     #self.db.removeTrajectory(traj)
+                else:
+                    log.info(f'keeping {traj.traj_id} {traj.traj_file_path}')
          
         return 
     


### PR DESCRIPTION
Fixes #35. 
This PR applies the following:

* a patch that finds and removes trajectories that are duplicates with the same trajectory ID. 

* JSON dataabase improvements: 
   * the JSON database was getting saved twice in succession, once by calling self.dh.SaveDatabase() explicitly, and then immediately after by calling self.dh.finish() which simply calls SaveDatabase(). The finish() call was only used in one place and didn't do anything else so i removed it. 

  * I found rare occasions where the JSON file could get either truncated or corrupted during saving. This normally happens if the host runs out of memory, but it crashes WMPL the next time the database is read becauses its zero-length or corrupt. I made two changes
    * I changed the code to only open the file when we're ready to save which reduces the window of opportunity for corruption. I think memory is being consumed during the deepcopy() operation. By moving this outside the scope of the open() we avoid having the file open for write when the crash happens. 
    * I put in checks during loading so that if the file is corrupt, it will attempt to recover from the last backup if available and so that it won't crash if the file exists but is invalid or zero length. 
    
* I also updated the readme with up-to-date instructions on how to solve the PROJ_LIB error. 

* Finally I added a 'verbose' flag to CorrelateRMS, which i'm using to disable some of the debug logging.  

I've tested this over several days on hydrid2 and on my own hardware. I discovered the JSON database issues on Hydrid2, where WMPL would crash after a few runs due to memory exhaustion while saving the database.  my VM only has 8GB memory. On my own hardware (16-core, 32GB, Ubuntu 20.04, python 3.11) i did not encounter any crashes or issues. 
