### PR TITLE
small  bugfix in Trajectory.py

### DIFF
--- a/wmpl/Trajectory/Trajectory.py
+++ b/wmpl/Trajectory/Trajectory.py
@@ -3406,7 +3406,7 @@ class Trajectory(object):
                 maxiter_list = [1000, None, 15000]
 
             # Try different methods to minimize timing residuals
-            for opt_method, opt, maxiter in zip(methods, maxiter_type, maxiter_list):
+            for opt_method, opt, maxiter in zip(methods, opt_list, maxiter_list):
 
                 # Run the minimization of residuals between all stations
                 timing_mini = scipy.optimize.minimize(timingResiduals, p0, args=(observations, \

--- a/wmpl/Trajectory/Trajectory.py
+++ b/wmpl/Trajectory/Trajectory.py
@@ -3396,20 +3396,22 @@ class Trajectory(object):
             # If there are more than 5 stations, use the advanced L-BFGS-B method by default
             if len(self.observations) >= 5:
                 methods = [None]
+                opt_list = ['maxiter']
                 maxiter_list = [15000]
 
             else:
                 # If there are less than 5, try faster methods first
                 methods = ['SLSQP', 'TNC', None]
+                opt_list = ['maxiter','maxfun','maxiter']
                 maxiter_list = [1000, None, 15000]
 
             # Try different methods to minimize timing residuals
-            for opt_method, maxiter in zip(methods, maxiter_list):
+            for opt_method, opt, maxiter in zip(methods, maxiter_type, maxiter_list):
 
                 # Run the minimization of residuals between all stations
                 timing_mini = scipy.optimize.minimize(timingResiduals, p0, args=(observations, \
                     self.stations_time_dict, weights), bounds=bounds, method=opt_method, 
-                    options={'maxiter': maxiter}, tol=1e-12)
+                    options={opt: maxiter}, tol=1e-12)
 
                 # Stop trying methods if this one was successful
                 if timing_mini.success:


### PR DESCRIPTION
bugfix in estimateTimingAndVelocity
scipy.optimize.minimize with method TNC takes option 'maxfun' not 'maxiter' as originally hardcoded.  
See https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.minimize.html

I noticed this because i was processing a small data set and spotted an error being printed to the console but not captured in the logs.  I think an error is not emitted in older versions of scipy and so the bug may have gone unnoticed previously. However without this fix ,timing estimation fails under certain circumstances, leading to differences in the solution.
Without the fix: 
```
Run No. 19
/home/mmcintyre/miniconda3/envs/wmpl311/lib/python3.11/site-packages/scipy/optimize/_numdiff.py:592: RuntimeWarning: invalid value encountered in subtract
  df = fun(x1) - f0
Unsuccessful timing optimization with SLSQP
**/home/mmcintyre/src/WesternMeteorPyLib/wmpl/Trajectory/Trajectory.py:3410: OptimizeWarning: Unknown solver options: maxiter**
  timing_mini = scipy.optimize.minimize(timingResiduals, p0, args=(observations, \
Unsuccessful timing optimization with TNC
Unsuccessful timing optimization with None
Timing difference and initial velocity minimization failed with the message:
ABNORMAL_TERMINATION_IN_LNSRCH
Try increasing the range of time offsets!
2025/02/26 11:58:33-INFO -CorrelateEngine:1006 - RA_g  =  75.264 deg
2025/02/26 11:58:33-INFO -CorrelateEngine:1007 - Deg_g = +64.293 deg
2025/02/26 11:58:33-INFO -CorrelateEngine:1008 - V_g   =  10.03 km/s
```
and with the fix, note four degrees difference in RA_g and about one degree in Deg_g
``` 
Run No. 19
Run No. 20
Run No. 15
Run No. 16
Run No. 18
20 successful MC runs done...
Computing uncertainties...
Computing covariance matrices...
2025/02/26 12:06:12-INFO -CorrelateEngine:998  - Monte-carlo phase complete
2025/02/26 12:06:12-INFO -CorrelateEngine:1005 -
2025/02/26 12:06:12-INFO -CorrelateEngine:1006 - RA_g  =  79.866 deg
2025/02/26 12:06:12-INFO -CorrelateEngine:1007 - Deg_g = +65.437 deg
2025/02/26 12:06:12-INFO -CorrelateEngine:1008 - V_g   =  10.24 km/s
```