### PR TITLE
Add gamma mass distribution and grain size model support to MetSim

### DIFF
--- a/wmpl/MetSim/GUI.py
+++ b/wmpl/MetSim/GUI.py
@@ -2988,6 +2988,7 @@ class MetSimGUI(QMainWindow):
         # Update shown grain diameters when the grain mass is updated
         self.inputErosionMassMin.editingFinished.connect(self.updateGrainDiameters)
         self.inputErosionMassMax.editingFinished.connect(self.updateGrainDiameters)
+        self.inputGrainModel.currentIndexChanged.connect(self.updateGrainModel)
 
         # Update the photometric mass when the luminous efficiency is changed
         self.inputLumEff.editingFinished.connect(self.updateInitialMass)
@@ -3237,7 +3238,6 @@ class MetSimGUI(QMainWindow):
         return radiated_energy, photom_mass
 
 
-
     def updateInputBoxes(self, show_previous=False):
         """ Update input boxes with values from the Constants object. """
 
@@ -3306,6 +3306,10 @@ class MetSimGUI(QMainWindow):
         self.inputErosionMassIndex.setText("{:.2f}".format(const.erosion_mass_index))
         self.inputErosionMassMin.setText("{:.2e}".format(const.erosion_mass_min))
         self.inputErosionMassMax.setText("{:.2e}".format(const.erosion_mass_max))
+        
+        # Set the combo box for the grain model
+        self.inputGrainModel.setCurrentIndex(0 if const.erosion_grain_distribution == 'powerlaw' else 1)
+
         self.inputErosionRhoChange.setText("{:d}".format(int(const.erosion_rho_change)))
         self.inputErosionAblationCoeffChange.setText("{:.4f}".format(const.erosion_sigma_change*1e6))
 
@@ -3412,6 +3416,12 @@ class MetSimGUI(QMainWindow):
             + "{:.0f}".format(1e6*grain_diam_max))
 
 
+    def updateGrainModel(self):
+        """ Update the grain model based on the selected option. """
+
+        # Read the grain model
+        self.const.erosion_grain_distribution = 'powerlaw' if self.inputGrainModel.currentIndex() == 0 \
+            else 'gamma'
 
 
     def checkBoxWakeSignal(self, event):
@@ -3466,6 +3476,7 @@ class MetSimGUI(QMainWindow):
         self.inputErosionMassIndex.setDisabled(not self.const.erosion_on)
         self.inputErosionMassMin.setDisabled(not self.const.erosion_on)
         self.inputErosionMassMax.setDisabled(not self.const.erosion_on)
+        self.inputGrainModel.setDisabled(not self.const.erosion_on)
 
         self.checkBoxErosionRhoSignal(None)
         self.checkBoxErosionAblationCoeffSignal(None)
@@ -3676,6 +3687,8 @@ class MetSimGUI(QMainWindow):
         self.const.erosion_mass_min = self._tryReadBox(self.inputErosionMassMin, self.const.erosion_mass_min)
         self.const.erosion_mass_max = self._tryReadBox(self.inputErosionMassMax, self.const.erosion_mass_max)
 
+        # Read the grain model combo box
+        self.updateGrainModel()
 
         # If a different density value after the change of erosion is used, read it
         if self.erosion_different_rho:

--- a/wmpl/MetSim/GUI.ui
+++ b/wmpl/MetSim/GUI.ui
@@ -1083,9 +1083,9 @@
      <property name="geometry">
       <rect>
        <x>220</x>
-       <y>90</y>
+       <y>30</y>
        <width>20</width>
-       <height>121</height>
+       <height>181</height>
       </rect>
      </property>
      <property name="orientation">
@@ -1129,6 +1129,42 @@
      </property>
      <property name="text">
       <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:6pt;&quot;&gt;log(m)&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+     </property>
+    </widget>
+    <widget class="QComboBox" name="inputGrainModel">
+     <property name="geometry">
+      <rect>
+       <x>280</x>
+       <y>190</y>
+       <width>101</width>
+       <height>23</height>
+      </rect>
+     </property>
+     <item>
+      <property name="text">
+       <string>powerlaw</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>gamma</string>
+      </property>
+     </item>
+    </widget>
+    <widget class="QLabel" name="label_78">
+     <property name="geometry">
+      <rect>
+       <x>210</x>
+       <y>190</y>
+       <width>59</width>
+       <height>15</height>
+      </rect>
+     </property>
+     <property name="text">
+      <string>model</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
      </property>
     </widget>
    </widget>

--- a/wmpl/MetSim/MetSimErosion.py
+++ b/wmpl/MetSim/MetSimErosion.py
@@ -162,6 +162,8 @@ class Constants(object):
         # Ablation coeff after erosion change
         self.erosion_sigma_change = self.sigma
 
+        # Grain distribution model ('powerlaw' mass or 'gamma' diameters)
+        self.erosion_grain_distribution = 'powerlaw'
 
         # Grain mass distribution index
         self.erosion_mass_index = 2.5
@@ -985,7 +987,7 @@ def ablateAll(fragments, const, compute_wake=False):
 
                 grain_children, const = generateFragments(const, frag, abs(mass_loss_erosion), \
                     frag.erosion_mass_index, frag.erosion_mass_min, frag.erosion_mass_max, \
-                    keep_eroding=False)
+                    keep_eroding=False, mass_model=const.erosion_grain_distribution)
 
                 const.n_active += len(grain_children)
                 frag_children_all += grain_children
@@ -1028,7 +1030,8 @@ def ablateAll(fragments, const, compute_wake=False):
                     # Generate larger fragments, possibly assign them a separate erosion coefficient
                     frag_children, const = generateFragments(const, frag, mass_frag_disruption, \
                         const.disruption_mass_index, disruption_mass_min, disruption_mass_max, \
-                        keep_eroding=const.erosion_on, disruption=True)
+                        keep_eroding=const.erosion_on, disruption=True, 
+                        mass_model=const.erosion_grain_distribution)
 
                     frag_children_all += frag_children
                     const.n_active += len(frag_children)
@@ -1052,7 +1055,7 @@ def ablateAll(fragments, const, compute_wake=False):
                 if mass_grain_disruption > 0:
                     grain_children, const = generateFragments(const, frag, mass_grain_disruption, 
                         frag.erosion_mass_index, frag.erosion_mass_min, frag.erosion_mass_max, \
-                        keep_eroding=False)
+                        keep_eroding=False, mass_model=const.erosion_grain_distribution)
 
                     frag_children_all += grain_children
                     const.n_active += len(grain_children)
@@ -1193,7 +1196,7 @@ def ablateAll(fragments, const, compute_wake=False):
                             # Generate dust grains
                             grain_children, const = generateFragments(const, frag_new, dust_mass, \
                                 frag_entry.mass_index, frag_entry.grain_mass_min, frag_entry.grain_mass_max, \
-                                keep_eroding=False)
+                                keep_eroding=False, mass_model=const.erosion_grain_distribution)
 
                             # Add fragments to the list
                             frag_children_all += grain_children


### PR DESCRIPTION
Introduce gamma mass distribution for fragment sizes and implement support for the gamma grain size model in MetSim. Update the UI to allow selection between grain models and ensure proper handling of grain model updates.