### PR TITLE
Add RC2001 deceleration correction and calcMass support

### DIFF
--- a/wmpl/MetSim/MetSimErosionCyTools.pyx
+++ b/wmpl/MetSim/MetSimErosionCyTools.pyx
@@ -376,7 +376,7 @@ cpdef double decelerationRK4(double dt, double K, double m, double rho_atm, doub
 
 
 @cython.cdivision(True) 
-cpdef double luminousEfficiency(int lum_eff_type, double lum_eff, double vel, double mass):
+cpdef double luminousEfficiency(int lum_eff_type, double lum_eff, double vel, double mass, double v_init=-1.0):
     """ Compute the luminous efficiency of the given type, velocity, and mass.
     
     Arguments:
@@ -393,13 +393,19 @@ cpdef double luminousEfficiency(int lum_eff_type, double lum_eff, double vel, do
         lum_eff: [double] Value of the constant luminous efficiency (percent).
         vel: [double] Velocity (m/s).
         mass: [double] Mass (kg).
+        v_init: [double] Initial velocity (m/s). If <= 0, the
+            velocity-dependent deceleration correction term from
+            Revelle & Ceplecha (2001) is not applied. Default is -1.
+            The Revelle & Ceplecha (2001) deceleration correction contains
+            log(v_init - vel). For v_init = vel, the correction is set to zero.
+            Values with v_init < vel are inconsistent and will fail.
 
     Return:
         tau: [double] Luminous efficiency (ratio).
 
     """
 
-    cdef double c1, c2
+    cdef double c1, c2, lv, decel, dv
 
     # Constant luminous efficiency
     if lum_eff_type == 0:
@@ -423,15 +429,41 @@ cpdef double luminousEfficiency(int lum_eff_type, double lum_eff, double vel, do
             c1 = -2.670
             c2 = -4.674
 
+        lv = log(vel/1000.0)
+
+        decel = 0.0
+
+        if v_init > 0:
+            # The Revelle & Ceplecha (2001) deceleration correction contains
+            # log(v_init - vel). For v_init = vel, the correction is set to zero.
+            # Values with v_init < vel are physically inconsistent and will fail.
+            dv = (v_init - vel)/1000.0
+
+            if dv == 0:
+                decel = 0.0
+            else:
+                decel = 0.26*log(dv) + 0.0042*log(dv)**3
 
         # Slow meteoroids
         if vel < 25372:
-            return (exp(c1 - 10.307*log(vel/1000.0) + 9.781*log(vel/1000.0)**2 - 3.0414*log(vel/1000.0)**3 \
-                + 0.3213*log(vel/1000.0)**4 + 1.15*tanh(0.38*log(mass))))/100.0
+            return exp(
+                c1
+                - 10.307*lv
+                + 9.781*lv**2
+                - 3.0414*lv**3
+                + 0.3213*lv**4
+                + 1.15*tanh(0.38*log(mass))
+                + decel
+            )/100.0
 
         # Fast meteoroids
         else:
-            return (exp(c2 + log(vel/1000.0) + 1.15*tanh(0.38*log(mass))))/100.0
+            return exp(
+                c2
+                + lv
+                + 1.15*tanh(0.38*log(mass))
+                + decel
+            )/100.0
 
     # Borovicka et al. (2013) - Kosice
     elif lum_eff_type == 4:

--- a/wmpl/MetSim/MetSimErosionCyTools.pyx
+++ b/wmpl/MetSim/MetSimErosionCyTools.pyx
@@ -393,12 +393,11 @@ cpdef double luminousEfficiency(int lum_eff_type, double lum_eff, double vel, do
         lum_eff: [double] Value of the constant luminous efficiency (percent).
         vel: [double] Velocity (m/s).
         mass: [double] Mass (kg).
-        v_init: [double] Initial velocity (m/s). If <= 0, the
-            velocity-dependent deceleration correction term from
-            Revelle & Ceplecha (2001) is not applied. Default is -1.
-            The Revelle & Ceplecha (2001) deceleration correction contains
-            log(v_init - vel). For v_init = vel, the correction is set to zero.
-            Values with v_init < vel are inconsistent and will fail.
+        v_init: [double] Pre-atmospheric velocity (m/s), only used by the Revelle & Ceplecha (2001)
+            models (types 1-3). If <= 0 (default -1), the deceleration correction term
+            0.26*ln(dv) + 0.0042*ln(dv)^3, where dv = (v_init - vel) in km/s, is not applied.
+            The correction diverges as dv -> 0, so for 0 < dv < 0.1 km/s it is linearly tapered
+            to zero, and for vel >= v_init it is set to zero (instead of producing a NaN).
 
     Return:
         tau: [double] Luminous efficiency (ratio).
@@ -406,6 +405,10 @@ cpdef double luminousEfficiency(int lum_eff_type, double lum_eff, double vel, do
     """
 
     cdef double c1, c2, lv, decel, dv
+
+    # Velocity difference (km/s) below which the Revelle & Ceplecha (2001) deceleration correction is
+    # linearly tapered to zero, keeping it bounded as it otherwise diverges to -inf as dv -> 0
+    cdef double dv_min = 0.1
 
     # Constant luminous efficiency
     if lum_eff_type == 0:
@@ -433,16 +436,19 @@ cpdef double luminousEfficiency(int lum_eff_type, double lum_eff, double vel, do
 
         decel = 0.0
 
+        # Deceleration correction using the velocity difference from the pre-atmospheric velocity
         if v_init > 0:
-            # The Revelle & Ceplecha (2001) deceleration correction contains
-            # log(v_init - vel). For v_init = vel, the correction is set to zero.
-            # Values with v_init < vel are physically inconsistent and will fail.
+
             dv = (v_init - vel)/1000.0
 
-            if dv == 0:
-                decel = 0.0
-            else:
+            if dv >= dv_min:
                 decel = 0.26*log(dv) + 0.0042*log(dv)**3
+
+            # Taper the correction linearly to zero below dv_min (it diverges as dv -> 0), and
+            # disable it for vel >= v_init (physically inconsistent input, avoid log of a
+            # non-positive number)
+            elif dv > 0:
+                decel = (dv/dv_min)*(0.26*log(dv_min) + 0.0042*log(dv_min)**3)
 
         # Slow meteoroids
         if vel < 25372:

--- a/wmpl/Utils/Physics.py
+++ b/wmpl/Utils/Physics.py
@@ -65,7 +65,6 @@ def dynamicPressure(lat, lon, height, jd, velocity, gamma=1.0):
     return dyn_pressure
 
 
-
 def dynamicMass(bulk_density, lat, lon, height, jd, velocity, decel, gamma=1.0, shape_factor=1.21):
     """ Calculate dynamic mass at the given point on meteor's trajectory. 
     
@@ -102,7 +101,6 @@ def dynamicMass(bulk_density, lat, lon, height, jd, velocity, decel, gamma=1.0, 
     dyn_mass = (1.0/(bulk_density**2))*((gamma*shape_factor*(velocity**2)*atm_dens)/decel)**3
 
     return dyn_mass
-
 
 
 def calcIntensity(mag_abs, P_0m=840.0):
@@ -158,8 +156,7 @@ def calcRadiatedEnergy(time, mag_abs, P_0m=840.0):
     return intens_int
 
 
-
-def calcMass(time, mag_abs, velocity, tau=0.007, P_0m=840.0, lum_eff_mass=-1):
+def calcMass(time, mag_abs, velocity, tau=0.007, P_0m=840.0, lum_eff_mass=-1, v_init=None):
     """ Calculates the mass of a meteoroid from the time and absolute magnitude.
 
     Arguments:
@@ -186,7 +183,15 @@ def calcMass(time, mag_abs, velocity, tau=0.007, P_0m=840.0, lum_eff_mass=-1):
         lum_eff_mass: [float] Meteoroid mass (kg) used to evaluate the mass-dependent luminous efficiency
             models. Ignored for a float tau. If -1 (default), the mass is iterated to self-consistency
             (compute mass -> recompute tau -> repeat until convergence).
-
+        v_init: [float or None] Pre-atmospheric velocity (m/s) used by the ReVelle & Ceplecha (2001)
+            deceleration correction in the luminous efficiency calculation. Default is None.
+            - None: the deceleration correction is not applied.
+            - -1: use the maximum velocity value in the velocity array as the pre-atmospheric velocity.
+              If v_init=-1 and velocity is scalar, the deceleration correction is not applied.
+            - >0: use the supplied value as the pre-atmospheric velocity.
+            NOTE: the velocity array should represent a fitted deceleration curve (i.e. a physically
+            consistent monotonic velocity evolution) rather than individual noisy measurements.
+            
     Return:
         mass: [float] Photometric mass of the meteoroid in kg.
 
@@ -200,14 +205,43 @@ def calcMass(time, mag_abs, velocity, tau=0.007, P_0m=840.0, lum_eff_mass=-1):
     #
     # For constant velocity and luminous efficiency this reduces to:
     #   M = (2/(tau*v^2))*integral(I dt)
+    #
+    # If tau is constant but velocity varies along the trajectory:
+    #   M = (2/tau)*integral(I/v^2 dt)
 
-    # A fixed luminous efficiency was given: compute the mass using that constant value.
+    if len(time) != len(mag_abs):
+        raise ValueError(
+            "time and mag_abs must have the same length."
+        )
+    
+    # If a velocity array is given, it must have the same length as the
+    # photometric measurements.
+    if not np.isscalar(velocity) and len(velocity) != len(time):
+        raise ValueError(
+            "Velocity array length ({:d}) does not match the number of "
+            "time/magnitude measurements ({:d}).".format(
+                len(velocity), len(time)
+            )
+        )
+    
+    if lum_eff_mass < 0 and lum_eff_mass != -1:
+        raise ValueError(
+            "lum_eff_mass must be >= 0 or -1 for self-consistent iteration."
+        )
+
+    # Constant luminous efficiency (tau given directly as a ratio).
     if not isinstance(tau, str) and not isinstance(tau, (bool, int)):
+        # Constant velocity
+        if np.isscalar(velocity):
+            intens_int = calcRadiatedEnergy(time, mag_abs, P_0m=P_0m)
+            return (2.0/(tau*velocity**2))*intens_int
 
-        intens_int = calcRadiatedEnergy(time, mag_abs, P_0m=P_0m)
-
-        return (2.0/(tau*velocity**2))*intens_int
-
+        # Velocity array
+        else:
+            intens = calcIntensity(mag_abs, P_0m=P_0m)
+            vel_arr = np.asarray(velocity, dtype=float)
+            dm_dt = 2.0*intens/(tau*vel_arr**2)
+            return simpson(dm_dt, x=time)
 
     # Velocity-dependent model: resolve the lum_eff_type code.
     if isinstance(tau, str):
@@ -226,14 +260,26 @@ def calcMass(time, mag_abs, velocity, tau=0.007, P_0m=840.0, lum_eff_mass=-1):
     # Radiated power at every measurement point
     intens = calcIntensity(mag_abs, P_0m=P_0m)
 
-    # Work with array velocity so a single code path handles scalar and array input
+
+    # Convert velocity to an array for the velocity-dependent luminous efficiency calculations.
     vel_arr = np.atleast_1d(np.asarray(velocity, dtype=float))
+
+    if v_init is None:
+        # Disable the ReVelle & Ceplecha deceleration correction
+        v_init_eff = -1.0
+    elif v_init == -1:
+        if np.isscalar(velocity):
+            v_init_eff = -1.0
+        else:
+            v_init_eff = float(np.max(vel_arr))
+    else:
+        v_init_eff = float(v_init)
 
     def _mass_for(mass_assumed):
         """ Compute the photometric mass given an assumed meteoroid mass for the lum. eff. models. """
 
         # Vectorize the scalar Cython call over the velocity points (lum_eff arg only used for type 0)
-        tau_arr = np.array([luminousEfficiency(lum_eff_type, 0.7, v, mass_assumed) for v in vel_arr])
+        tau_arr = np.array([luminousEfficiency(lum_eff_type, 0.7, v, mass_assumed, v_init_eff) for v in vel_arr])
 
         # Integrate the instantaneous mass-loss rate dm/dt = 2*I/(tau*v^2)
         dm_dt = 2.0*intens/(tau_arr*vel_arr**2)
@@ -262,9 +308,13 @@ def calcMass(time, mag_abs, velocity, tau=0.007, P_0m=840.0, lum_eff_mass=-1):
             mass = mass_new
             break
         mass = mass_new
+    else:
+        print(
+            "WARNING: luminous efficiency self-consistency iteration "
+            "did not converge after 50 iterations."
+        )
 
     return mass
-
 
 
 def calcKB(lat, lon, ht_beg, jd, v, zenith_angle, gmn_correction=False):

--- a/wmpl/Utils/Physics.py
+++ b/wmpl/Utils/Physics.py
@@ -184,14 +184,17 @@ def calcMass(time, mag_abs, velocity, tau=0.007, P_0m=840.0, lum_eff_mass=-1, v_
             models. Ignored for a float tau. If -1 (default), the mass is iterated to self-consistency
             (compute mass -> recompute tau -> repeat until convergence).
         v_init: [float or None] Pre-atmospheric velocity (m/s) used by the ReVelle & Ceplecha (2001)
-            deceleration correction in the luminous efficiency calculation. Default is None.
+            deceleration correction in the luminous efficiency calculation. Only affects the RC2001
+            models (tau = 1, 2, 3 or 'rc2001*'). Default is None.
             - None: the deceleration correction is not applied.
-            - -1: use the maximum velocity value in the velocity array as the pre-atmospheric velocity.
-              If v_init=-1 and velocity is scalar, the deceleration correction is not applied.
+            - -1: estimate the pre-atmospheric velocity as the median velocity over the first 25% of
+              points (robust to measurement noise). Requires a velocity array.
             - >0: use the supplied value as the pre-atmospheric velocity.
+            The correction is linearly tapered to zero for velocities within 0.1 km/s of v_init and
+            disabled for velocities at or above it (see luminousEfficiency() for details).
             NOTE: the velocity array should represent a fitted deceleration curve (i.e. a physically
             consistent monotonic velocity evolution) rather than individual noisy measurements.
-            
+
     Return:
         mass: [float] Photometric mass of the meteoroid in kg.
 
@@ -210,31 +213,23 @@ def calcMass(time, mag_abs, velocity, tau=0.007, P_0m=840.0, lum_eff_mass=-1, v_
     #   M = (2/tau)*integral(I/v^2 dt)
 
     if len(time) != len(mag_abs):
-        raise ValueError(
-            "time and mag_abs must have the same length."
-        )
-    
-    # If a velocity array is given, it must have the same length as the
-    # photometric measurements.
-    if not np.isscalar(velocity) and len(velocity) != len(time):
-        raise ValueError(
-            "Velocity array length ({:d}) does not match the number of "
-            "time/magnitude measurements ({:d}).".format(
-                len(velocity), len(time)
-            )
-        )
-    
+        raise ValueError("time and mag_abs must have the same length.")
+
+    # If a velocity array is given, it must have the same length as the photometric measurements
+    if np.ndim(velocity) > 0 and len(velocity) != len(time):
+        raise ValueError("Velocity array length ({:d}) does not match the number of time/magnitude "
+            "measurements ({:d}).".format(len(velocity), len(time)))
+
     if lum_eff_mass < 0 and lum_eff_mass != -1:
-        raise ValueError(
-            "lum_eff_mass must be >= 0 or -1 for self-consistent iteration."
-        )
+        raise ValueError("lum_eff_mass must be >= 0, or -1 for self-consistent iteration.")
 
     # Constant luminous efficiency (tau given directly as a ratio).
     if not isinstance(tau, str) and not isinstance(tau, (bool, int)):
+
         # Constant velocity
-        if np.isscalar(velocity):
+        if np.ndim(velocity) == 0:
             intens_int = calcRadiatedEnergy(time, mag_abs, P_0m=P_0m)
-            return (2.0/(tau*velocity**2))*intens_int
+            return (2.0/(tau*float(velocity)**2))*intens_int
 
         # Velocity array
         else:
@@ -264,16 +259,38 @@ def calcMass(time, mag_abs, velocity, tau=0.007, P_0m=840.0, lum_eff_mass=-1, v_
     # Convert velocity to an array for the velocity-dependent luminous efficiency calculations.
     vel_arr = np.atleast_1d(np.asarray(velocity, dtype=float))
 
+    # Resolve the pre-atmospheric velocity used by the ReVelle & Ceplecha (2001) deceleration
+    # correction (only affects the RC2001 models, types 1-3)
     if v_init is None:
-        # Disable the ReVelle & Ceplecha deceleration correction
+
+        # Disable the deceleration correction
         v_init_eff = -1.0
+
     elif v_init == -1:
-        if np.isscalar(velocity):
-            v_init_eff = -1.0
-        else:
-            v_init_eff = float(np.max(vel_arr))
-    else:
+
+        # A scalar velocity carries no deceleration information to estimate v_init from
+        if np.ndim(velocity) == 0:
+            raise ValueError("v_init=-1 requires a velocity array to estimate the pre-atmospheric "
+                "velocity.")
+
+        # Estimate the pre-atmospheric velocity as the median velocity over the first 25% of points,
+        # which is robust to measurement noise (unlike e.g. the maximum velocity)
+        v_init_eff = float(np.median(vel_arr[:max(1, len(vel_arr)//4)]))
+
+    elif v_init > 0:
+
         v_init_eff = float(v_init)
+
+        # The deceleration correction is tapered/disabled for velocities within 0.1 km/s of v_init,
+        # so warn if the given v_init leaves the fastest points effectively uncorrected
+        if v_init_eff < np.max(vel_arr) + 100:
+            print("WARNING: v_init = {:.1f} m/s is within 100 m/s of the maximum given velocity. "
+                "The ReVelle & Ceplecha (2001) deceleration correction will be tapered or disabled "
+                "at the fastest points.".format(v_init_eff))
+
+    else:
+        raise ValueError("v_init must be None, -1 (automatic estimate), or > 0, "
+            "got {}".format(v_init))
 
     def _mass_for(mass_assumed):
         """ Compute the photometric mass given an assumed meteoroid mass for the lum. eff. models. """
@@ -309,10 +326,8 @@ def calcMass(time, mag_abs, velocity, tau=0.007, P_0m=840.0, lum_eff_mass=-1, v_
             break
         mass = mass_new
     else:
-        print(
-            "WARNING: luminous efficiency self-consistency iteration "
-            "did not converge after 50 iterations."
-        )
+        print("WARNING: luminous efficiency self-consistency iteration did not converge "
+            "after 50 iterations.")
 
     return mass
 


### PR DESCRIPTION
This PR improves the implementation of the luminous efficiency model from ReVelle & Ceplecha (2001) and its application in photometric mass estimation.

Changes:
- Added support for the velocity-dependent deceleration correction term described by ReVelle & Ceplecha (2001).
- Extended luminousEfficiency() with an optional v_init argument representing the pre-atmospheric velocity.
- Implemented the ReVelle & Ceplecha (2001) deceleration correction using the velocity difference (v_init - vel).
- For v_init = vel, the deceleration correction is set to zero.
- Velocity values larger than v_init are treated as physically inconsistent and will cause the logarithm evaluation to fail.
- Added documentation describing the assumptions and validity limits of the deceleration correction term.

Photometric mass calculation (calcMass):
- Added support for passing a pre-atmospheric velocity through the new v_init argument.
- Added three operating modes for the ReVelle & Ceplecha deceleration correction:
    - v_init=None: do not apply the correction (it translates into -1 for luminousEfficiency()).
    - v_init=-1: use the maximum value of the supplied velocity profile as the pre-atmospheric velocity.
    - v_init>0: use the user-provided pre-atmospheric velocity.
- Updated the documentation to clarify the expected use of velocity profiles and the assumptions behind the automatic pre-atmospheric velocity selection.

Velocity-dependent mass integration:
- Fixed the treatment of variable velocity when a constant luminous efficiency is supplied.
- The mass is now computed using
    M = \frac{2}{\tau}\int \frac{I}{v^2},dt
    when a velocity profile is provided, instead of incorrectly assuming constant velocity.

Input validation:
- Added validation that time and mag_abs have identical lengths.
- Added validation that velocity arrays have the same length as the photometric measurements.
- Added validation for lum_eff_mass, which must be either:
    - -1 (self-consistent iteration), or
    - a non-negative mass value.

Self-consistent luminous efficiency iteration:
- Added a warning message when the luminous-efficiency self-consistency iteration fails to converge after the maximum number of iterations.
- Improved documentation of the convergence procedure and mass iteration workflow.

Documentation:
- Expanded the documentation of calcMass() and luminousEfficiency().
- Clarified the distinction between constant and velocity-dependent luminous efficiency calculations.
- Added documentation for the new pre-atmospheric velocity handling and associated assumptions.