### PR TITLE
Fix MetSim saved orbit: consistent state vector + correct calcOrbit flags

### DIFF
--- a/wmpl/MetSim/GUI.py
+++ b/wmpl/MetSim/GUI.py
@@ -6047,16 +6047,28 @@ class MetSimGUI(QMainWindow):
         v_init_diff = self.const.v_init - self.traj.orbit.v_init
 
         # Recompute the orbit with an increased initial velocity
+        # Reuse the same frame convention (moving vs fixed stations) that the original orbit solve used,
+        #   otherwise plane-intersection-solved events would be recomputed with the wrong convention.
+        #   Old pickles without this attribute default to the LoS-success case (moving stations).
+        los_success = getattr(self.traj, 'orbit_los_success', True)
         orb = calcOrbit(self.traj.radiant_eci_mini, self.traj.v_init + v_init_diff, self.traj.v_avg \
-            + v_init_diff, self.traj.state_vect_mini, self.traj.rbeg_jd)
+            + v_init_diff, self.traj.state_vect_mini, self.traj.rbeg_jd, \
+            stations_fixed=(not los_success), reference_init=los_success, \
+            v_init_stddev_direct=self.traj.v_init_stddev)
 
 
         print(orb)
 
-        
+
         # Make a file name for the report
         traj_updated = copy.deepcopy(self.traj)
         traj_updated.orbit = orb
+
+        # Sync the velocities used elsewhere in the report (e.g. the printed ECI state vector) with the
+        #   recomputed orbit, so the state vector and the orbit are internally consistent and integrating
+        #   the printed state vector reproduces the recorded orbit.
+        traj_updated.v_init = orb.v_init
+        traj_updated.v_avg = orb.v_avg
         dir_path, file_name = os.path.split(self.traj_path)
         report_file_name = file_name.replace('trajectory.pickle', '') + 'report_sim.txt'
 

--- a/wmpl/Trajectory/Trajectory.py
+++ b/wmpl/Trajectory/Trajectory.py
@@ -6692,6 +6692,11 @@ class Trajectory(object):
             # Calculate the orbit of the meteor
             # If the LoS estimation failed, then the plane intersection solution will be used for the orbit,
             # which needs to have fixed stations and the average velocity should be the reference velocity
+
+            # Store the orbit-solve convention so it can be reused when the orbit is recomputed later
+            #   (e.g. by MetSim's saveUpdatedOrbit)
+            self.orbit_los_success = bool(minimize_solution.success)
+
             self.orbit = calcOrbit(self.radiant_eci_mini, self.v_init, self.v_avg, self.state_vect_mini, \
                 self.rbeg_jd, stations_fixed=(not minimize_solution.success), \
                 reference_init=minimize_solution.success, v_init_stddev_direct=self.v_init_stddev)


### PR DESCRIPTION
## What this fixes

A colleague noticed that the orbit saved by MetSim (`*_report_sim.txt`) doesn't match what you get if you integrate the ECI state vector printed in that same file. The regular trajectory report (`*_report.txt`) does not have this problem. The worst example was the Draconid event `20241008_024504`.

## What was going on (in simple terms)

The whole point of the MetSim simulation is to **correct the observed initial velocity for deceleration** and find a better (usually higher) initial speed. When you save the updated orbit from the GUI, that corrected, simulated speed is used to compute the orbit — which is exactly what we want, and that part was always correct.

The problem was purely in what the report **displayed**:

- The **Orbit** block was computed from the *simulated* speed. ✅
- The **State vector** block in the same report was still printed using the *original observed* speed. ❌

That happens because the state vector velocity is written as `v_init * radiant_eci_mini`, and `saveUpdatedOrbit()` replaced only the `.orbit` on the copied trajectory object — it left `traj.v_init` at the original observed value. So the report showed one speed for the state vector and a different speed for the orbit. Anyone integrating the printed state vector therefore reproduced the *observed-speed* orbit, not the *saved* orbit — exactly the discrepancy that was reported.

Concretely for the reported event: the state-vector velocity magnitude was 24.78 km/s while the orbit's `Vinit` was 24.46 km/s. In the regular report the two match (23.83 = 23.83).

## Second, smaller bug

`saveUpdatedOrbit()` called `calcOrbit()` **without** the keyword flags the original solve uses (`stations_fixed`, `reference_init`, `v_init_stddev_direct`), so they silently fell back to defaults. For the common case (line-of-sight fit succeeded) the defaults happen to match. But for events solved via the plane-intersection fallback, the orbit was recomputed in the **wrong frame convention** and would be genuinely wrong.

## The fix

1. **`wmpl/Trajectory/Trajectory.py`** — store `self.orbit_los_success` at orbit-computation time so the frame convention can be reused when the orbit is recomputed later.
2. **`wmpl/MetSim/GUI.py` (`saveUpdatedOrbit`)**:
   - Forward `stations_fixed` / `reference_init` / `v_init_stddev_direct` to `calcOrbit`, reusing the original convention (defaulting to the LoS-success case for old pickles that predate the new attribute).
   - Set `traj_updated.v_init` and `traj_updated.v_avg` to the recomputed orbit's values, so the printed state vector uses the **same simulated speed** as the orbit.

After the fix the whole `_report_sim.txt` is internally consistent around the simulated speed: the saved orbit uses the simulated (deceleration-corrected) speed, and the printed state vector matches it.

## Verification

Ran a reproduction on the real event pickle (`20241008_024504_trajectory.pickle`):
- **Internal consistency**: printed state-vector `|V|` now equals the orbit `Vinit` exactly.
- **Round-trip**: integrating the printed state-vector velocity back through `calcOrbit` reproduces the saved orbit's `a`, `e`, `i`, `q` to numerical precision.
- **Backward compatibility**: old pickles without `orbit_los_success` fall back to the LoS-success convention via `getattr(..., True)`, matching prior behaviour.

Note: `orbit_los_success` is only populated on newly-solved trajectories. Orbits recomputed from existing (pre-fix) pickles use the safe LoS-success default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
