### PR TITLE
fix for #71, mathtext causing python runtime to emit SyntaxError warnings

### DIFF
--- a/wmpl/Analysis/FitPopulationAndMassIndex.py
+++ b/wmpl/Analysis/FitPopulationAndMassIndex.py
@@ -279,7 +279,7 @@ def estimateIndex(input_data, ref_point=None, mass=False, show_plots=False, plot
         ref_point_std = np.nanstd(ref_point_unc_list)
         
         plt.scatter(sign*ref_point, slope_pdf, color='r', zorder=5, \
-            label='Reference point = {:.2f} $\pm$ {:.2f}'.format(sign*ref_point, ref_point_std))
+            label='Reference point = {:.2f} $\\pm$ {:.2f}'.format(sign*ref_point, ref_point_std))
 
         plt.scatter(sign*inflection_point, scipy.stats.gamma.pdf(inflection_point, *params), color='r', \
             marker='x', zorder=5, label='Inflection point = {:.2f}'.format(sign*inflection_point))
@@ -336,11 +336,11 @@ def estimateIndex(input_data, ref_point=None, mass=False, show_plots=False, plot
         # Plot the inflection point
         y_temp = np.log10(scipy.stats.gamma.sf(ref_point, *params))
         plt.scatter(sign*ref_point, 10**y_temp, c='r', \
-            label='Reference point = {:.2f} $\pm$ {:.2f}'.format(sign*ref_point, ref_point_std), zorder=5)
+            label='Reference point = {:.2f} $\\pm$ {:.2f}'.format(sign*ref_point, ref_point_std), zorder=5)
 
         # Plot the tangential line with the slope
         plt.plot(sign*x_arr, logline(-x_arr, slope, intercept), color='r', \
-            label='{:s} = {:.2f} $\pm$ {:.2f}, [{:.2f}, {:.2f}] 95% CI\nKS test D = {:.3f} \nKS test p-value = {:.3f}'.format(\
+            label='{:s} = {:.2f} $\\pm$ {:.2f}, [{:.2f}, {:.2f}] 95% CI\nKS test D = {:.3f} \nKS test p-value = {:.3f}'.format(\
                 slope_name, slope_report, slope_report_std, slope_report_95ci_lower, slope_report_95ci_upper,\
                 kstest.statistic, kstest.pvalue), zorder=5)
 
@@ -357,7 +357,7 @@ def estimateIndex(input_data, ref_point=None, mass=False, show_plots=False, plot
         else:
             lim_label = "Eff. lim. mag"
         plt.scatter(lim_point, 1.0, c='b', marker='s', \
-            label="{:s} = {:+.2f} $\pm$ {:.2f}, [{:.2f}, {:.2f}] 95% CI".format(
+            label="{:s} = {:+.2f} $\\pm$ {:.2f}, [{:.2f}, {:.2f}] 95% CI".format(
                 lim_label, 
                 lim_point, 
                 lim_point_std, 

--- a/wmpl/TrajSim/AnalyzeErrorEstimation.py
+++ b/wmpl/TrajSim/AnalyzeErrorEstimation.py
@@ -190,7 +190,7 @@ if __name__ == "__main__":
 
         plt.xlim(xmax=4)
         plt.ylim([0, 1.0])
-        plt.xlabel('True radiant error ($\sigma$)')
+        plt.xlabel('True radiant error ($\\sigma$)')
         plt.ylabel('Cumulative normalized count')
 
         plt.grid(color='0.8')

--- a/wmpl/TrajSim/AnalyzeTrajectories.py
+++ b/wmpl/TrajSim/AnalyzeTrajectories.py
@@ -336,9 +336,9 @@ def plotRadiants(pickle_trajs, plot_type='geocentric', ra_cent=None, dec_cent=No
         ra_stddev = np.degrees(scipy.stats.circstd(x_list))
         dec_stddev = np.degrees(np.std(y_list))
 
-        label += "{:d} orbits, $\sigma_{{RA}}$ = {:.2f}$\degree$".format(len(x_list), ra_stddev)
+        label += "{:d} orbits, $\\sigma_{{RA}}$ = {:.2f}$\\degree$".format(len(x_list), ra_stddev)
         label += ", "
-        label += "$\sigma_{{Dec}}$ = {:.2f}$\degree$".format(dec_stddev)
+        label += "$\\sigma_{{Dec}}$ = {:.2f}$\\degree$".format(dec_stddev)
 
 
     plt_handle.scatter(x_list, y_list, c=z_list, label=label, **kwargs)
@@ -583,7 +583,7 @@ def compareTrajToSim(dir_path, sim_meteors, traj_list, solver_name, radiant_exte
     plt.xlim(0, radiant_extent)
     plt.ylim(-vg_extent, vg_extent)
 
-    plt.title('{:s}, failures: {:d}, $\sigma_R$ = {:.2f} deg, $\sigma_V$ = {:.2f} km/s'.format(solver_name, \
+    plt.title('{:s}, failures: {:d}, $\\sigma_R$ = {:.2f} deg, $\\sigma_V$ = {:.2f} km/s'.format(solver_name, \
         failed_count, radiant_std, vg_std))
 
     plt.xlabel('Radiant difference (deg)')
@@ -1160,9 +1160,9 @@ if __name__ == "__main__":
 
     # label = 'MPF:'
 
-    # label += " $\sigma_{{RA}}$ = {:.2f}$\degree$".format(ra_stddev)
+    # label += " $\\sigma_{{RA}}$ = {:.2f}$\\degree$".format(ra_stddev)
     # label += ", "
-    # label += "$\sigma_{{Dec}}$ = {:.2f}$\degree$".format(dec_stddev)
+    # label += "$\\sigma_{{Dec}}$ = {:.2f}$\\degree$".format(dec_stddev)
 
     # m.scatter(ra_list, dec_list, c=vg_list, label=label, marker='o', s=10)
 


### PR DESCRIPTION
As explained in #71, mathtex in matplot plot labels causes Python 3.11+ to emit a syntax warning as the \ is treated as starting an escape sequence. Hence \pm is treated as the escape sequence \p which is not a valid sequence. Its harmless but can be silenced by escaping the \ as is already being done in many other label strings. 