### PR TITLE
fix for #68, calculation of lam_err in AggregateAndPlot causes a crash

### DIFF
--- a/wmpl/Trajectory/AggregateAndPlot.py
+++ b/wmpl/Trajectory/AggregateAndPlot.py
@@ -1014,12 +1014,13 @@ def generateShowerPlots(dir_path, traj_list, min_members=30, max_radiant_err=0.5
         lam_sol_data = (lam_data - sol_data) % (2*np.pi)
 
         # Get the errors
-        if traj.uncertainties is not None:
-            lam_err = np.array([traj.uncertainties.L_g for traj in shower_trajs])
-            bet_err = np.array([traj.uncertainties.B_g for traj in shower_trajs])
-        else:
-            lam_err = np.array([1 for traj in shower_trajs])
-            bet_err = np.array([1 for traj in shower_trajs])
+        lam_err = np.array([1.0] * len(shower_trajs))
+        bet_err = np.array([1.0] * len(shower_trajs))
+        for i, traj in enumerate(shower_trajs):
+            if traj.uncertainties is not None and hasattr(traj.uncertainties, 'L_g'):
+                lam_err[i] = traj.uncertainties.L_g
+                bet_err[i] = traj.uncertainties.B_g
+
         # Compute masses (only take trajectories which are completely inside the FOV, otherwise set the 
         #   mass to None)
         mass_data = np.array([computeMass(traj, P_0m) if all(checkMeteorFOVBegEnd(traj)) else None 


### PR DESCRIPTION
As per #68, the logic used to create lam_err and bet_err failed if one of the trajectories did not have all uncertainties data. 

As written, the code checked whether `traj` contained the `uncertainties` member. However `traj` was never properly defined, and was purely by accident the last element in the `shower_trajs` list. If this element contained `uncertainties`, but other elements in the list did not, then the code would crash because `uncertainties.L_g` was not defined. 
The workaround sets all uncertainties to 1.0 then overrides the value on a traj-by-traj case. 