### PR TITLE
REBOUND: clear error when rebound/reboundx are missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,12 +65,24 @@ conda install -y -c conda-forge basemap basemap-data-hires
 conda install -y -c conda-forge cartopy paramiko
 ```
 
-Optionally, if you want to use the REBOUND orbital integrator (Linux-only!), install:
+Optionally, if you want to use the REBOUND orbital integrator, install:
 
 ```
 conda install -y -c conda-forge astropy
 conda install -y -c conda-forge rebound
 pip install reboundx
+```
+
+**Platform note:** this works on **Linux and macOS**. It does **not** work on native
+Windows: `reboundx` has no Windows wheel and no conda-forge build, so `pip` compiles it
+from source with MSVC, which fails (`gr_full.c: error C2057: expected constant expression`)
+because `reboundx` uses C99 variable-length arrays that MSVC does not support. On Windows,
+use the **Windows Subsystem for Linux (WSL2)** — install an Ubuntu distribution, set up the
+`wmpl` conda environment inside it, and run the above there; `reboundx` then builds cleanly
+with `gcc`. Installing only `rebound` is not enough — `reboundx` must import too. Verify with:
+
+```
+python -c "import rebound, reboundx; print('ok')"
 ```
 
 

--- a/wmpl/Rebound/REBOUND.py
+++ b/wmpl/Rebound/REBOUND.py
@@ -1,4 +1,11 @@
-""" Functions for running REBOUND simulations on wmpl trajectories. """
+""" Functions for running REBOUND simulations on wmpl trajectories.
+
+Requires the 'rebound' and 'reboundx' packages. These work on Linux and macOS. They do NOT
+install on native Windows: 'reboundx' has no Windows wheel and does not compile with MSVC
+(it uses C99 variable-length arrays MSVC does not support). On Windows, use the Windows
+Subsystem for Linux (WSL2) - install Ubuntu, set up the wmpl conda environment there, and run
+from that shell. Installing only 'rebound' is not enough; 'reboundx' must import too.
+"""
 
 import os
 import re

--- a/wmpl/Rebound/REBOUND.py
+++ b/wmpl/Rebound/REBOUND.py
@@ -877,6 +877,22 @@ if __name__ == "__main__":
     from wmpl.Utils.Pickling import loadPickle
 
 
+    # Exit cleanly with a helpful message if REBOUND/REBOUNDx are not installed, instead of
+    # crashing later with a cryptic "cannot unpack non-iterable NoneType" error.
+    if not REBOUND_FOUND:
+        print("")
+        print("ERROR: the 'rebound' and 'reboundx' packages are required to run this script, "
+              "but they could not be imported.")
+        print("")
+        print("Install them with:  pip install rebound reboundx")
+        print("")
+        print("Note: on Windows, 'reboundx' has no prebuilt wheel and does not compile with the "
+              "MSVC compiler (it uses C features MSVC lacks). Use one of:")
+        print("  - Windows Subsystem for Linux (WSL2, e.g. Ubuntu) - recommended, builds cleanly, or")
+        print("  - a Linux or macOS machine.")
+        print("'rebound' alone is not enough; 'reboundx' must import successfully too.")
+        sys.exit(1)
+
     ###
 
     parser = argparse.ArgumentParser(description="Run REBOUND simulation for a given trajectory pickle file. The simulation is run 60 days backwards by default.")


### PR DESCRIPTION
## Problem
A student on Windows hit:
```
REBOUND package not found. Install REBOUND and reboundx packages ...
TypeError: cannot unpack non-iterable NoneType object
```
When `rebound`/`reboundx` fail to import, `reboundSimulate` returns `None` and the CLI crashes unpacking it — the real cause (missing/failed `reboundx`) is buried.

## Fix
Check `REBOUND_FOUND` at the top of the `__main__` block and `sys.exit(1)` with a helpful message: install command, and a note that **`reboundx` has no Windows wheel and does not compile with MSVC** (it uses C99 variable-length arrays MSVC rejects — the `gr_full.c: error C2057` seen in the report), so use **WSL2** or Linux/macOS. Also notes that installing only `rebound` is insufficient — `reboundx` must import too.

No behavior change when the packages are present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)