### PR TITLE
Surface the real error when rebound/reboundx import fails

### DIFF
--- a/wmpl/Rebound/REBOUND.py
+++ b/wmpl/Rebound/REBOUND.py
@@ -33,8 +33,11 @@ try:
 
     REBOUND_FOUND = True
 
-except ImportError:
-    print("REBOUND package not found. Install REBOUND and reboundx packages to use the REBOUND functions.")
+except ImportError as e:
+    # Surface the actual import error instead of a generic "not found" message, so a real failure
+    #   (e.g. a broken dependency) isn't misreported as a missing package the user already has.
+    print("REBOUND/reboundx could not be imported: {}".format(e))
+    print("Install or upgrade the rebound and reboundx packages to use the REBOUND functions.")
     REBOUND_FOUND = False
 
 from wmpl.Config import config


### PR DESCRIPTION
## What

When `rebound`/`reboundx` fail to import, `wmpl/Rebound/REBOUND.py` caught `ImportError` and always printed a fixed message:

```python
except ImportError:
    print("REBOUND package not found. Install REBOUND and reboundx packages ...")
    REBOUND_FOUND = False
```

The actual exception was discarded. If the import failed for any *real* reason (a broken dependency, an ABI mismatch, etc.), the user was told to reinstall packages they already have, with no clue as to the true cause.

Now the real exception is surfaced:

```python
except ImportError as e:
    print("REBOUND/reboundx could not be imported: {}".format(e))
    print("Install or upgrade the rebound and reboundx packages to use the REBOUND functions.")
    REBOUND_FOUND = False
```

## Why

Raised by @markmac99 in review of 11f20d0e — thanks for the vigilance. His specific worry (setuptools ≥81 removing `pkg_resources` → silent rebound import failure) turns out not to occur: reboundx guards its own `pkg_resources` use in a bare `try/except: pass`, so that failure never propagates to us (verified by simulating the removal — `import reboundx` still succeeds). But his broader point stands: our handler was hiding the real error, which this PR fixes for the general case.

## Notes

- No change to `REBOUND_FOUND` behavior — same control flow, better diagnostics.
- Scoped to the import guard only; the narrow `pkg_resources` warning filter is left as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)