### PR TITLE
Quieten rebound by moving error reporting

### DIFF
--- a/wmpl/Rebound/REBOUND.py
+++ b/wmpl/Rebound/REBOUND.py
@@ -32,13 +32,13 @@ try:
     import astropy.time
 
     REBOUND_FOUND = True
+    rebound_err = None
 
 except ImportError as e:
     # Surface the actual import error instead of a generic "not found" message, so a real failure
     #   (e.g. a broken dependency) isn't misreported as a missing package the user already has.
-    print("REBOUND/reboundx could not be imported: {}".format(e))
-    print("Install or upgrade the rebound and reboundx packages to use the REBOUND functions.")
     REBOUND_FOUND = False
+    rebound_err = e
 
 from wmpl.Config import config
 from wmpl.Utils.TrajConversions import (
@@ -893,6 +893,7 @@ if __name__ == "__main__":
         print("")
         print("ERROR: the 'rebound' and 'reboundx' packages are required to run this script, "
               "but they could not be imported.")
+        print("The error was: {}".format(rebound_err))        
         print("")
         print("Install them with:  pip install rebound reboundx")
         print("")

--- a/wmpl/Rebound/REBOUND.py
+++ b/wmpl/Rebound/REBOUND.py
@@ -22,6 +22,9 @@ import matplotlib.pyplot as plt
 
 from jplephem.spk import SPK
 
+REBOUND_FOUND = False
+_REBOUND_IMPORT_ERROR = None
+
 try:
     # Silence the noisy "pkg_resources is deprecated" warning emitted while importing reboundx
     with warnings.catch_warnings():
@@ -32,13 +35,11 @@ try:
     import astropy.time
 
     REBOUND_FOUND = True
-    rebound_err = None
 
 except ImportError as e:
-    # Surface the actual import error instead of a generic "not found" message, so a real failure
-    #   (e.g. a broken dependency) isn't misreported as a missing package the user already has.
-    REBOUND_FOUND = False
-    rebound_err = e
+    # Keep optional-dependency failures quiet during import. Report the actual cause only if a
+    #   REBOUND function or the command-line interface is used.
+    _REBOUND_IMPORT_ERROR = str(e)
 
 from wmpl.Config import config
 from wmpl.Utils.TrajConversions import (
@@ -52,6 +53,24 @@ from wmpl.Utils.TrajConversions import (
 )
 from wmpl.Utils.Math import rotateVector
 from wmpl.Utils.Earth import calcTrueObliquity
+
+
+def _printReboundUnavailable(include_install_help=False):
+    """ Print the captured REBOUND import failure when REBOUND is intentionally used. """
+
+    print("ERROR: the 'rebound' and 'reboundx' packages are required, but they could not be imported.")
+    if _REBOUND_IMPORT_ERROR is not None:
+        print("The error was: {}".format(_REBOUND_IMPORT_ERROR))
+
+    if include_install_help:
+        print("")
+        print("Install them with:  pip install rebound reboundx")
+        print("")
+        print("Note: on Windows, 'reboundx' has no prebuilt wheel and does not compile with the "
+              "MSVC compiler (it uses C features MSVC lacks). Use one of:")
+        print("  - Windows Subsystem for Linux (WSL2, e.g. Ubuntu) - recommended, builds cleanly, or")
+        print("  - a Linux or macOS machine.")
+        print("'rebound' alone is not enough; 'reboundx' must import successfully too.")
 
 
 # Hill-sphere radii in AU used for close-encounter detection. The Moon (Luna) uses its
@@ -322,7 +341,7 @@ def convertToBarycentric(state_vect, jd, log_file_path="", ephem_source="local",
 
     # Skip if REBOUND is not found
     if not REBOUND_FOUND:
-        print("REBOUND package not found. Install REBOUND and reboundx packages to use the REBOUND functions.")
+        _printReboundUnavailable()
         return None
 
     # If a log file is specified, open it
@@ -665,7 +684,7 @@ def reboundSimulate(
 
     # Skip if REBOUND is not found
     if not REBOUND_FOUND:
-        print("REBOUND package not found. Install REBOUND and reboundx packages to use the REBOUND functions.")
+        _printReboundUnavailable()
         return None
 
     # If the trajectory is given, override the julian_date and state_vect arguments
@@ -891,17 +910,7 @@ if __name__ == "__main__":
     # crashing later with a cryptic "cannot unpack non-iterable NoneType" error.
     if not REBOUND_FOUND:
         print("")
-        print("ERROR: the 'rebound' and 'reboundx' packages are required to run this script, "
-              "but they could not be imported.")
-        print("The error was: {}".format(rebound_err))        
-        print("")
-        print("Install them with:  pip install rebound reboundx")
-        print("")
-        print("Note: on Windows, 'reboundx' has no prebuilt wheel and does not compile with the "
-              "MSVC compiler (it uses C features MSVC lacks). Use one of:")
-        print("  - Windows Subsystem for Linux (WSL2, e.g. Ubuntu) - recommended, builds cleanly, or")
-        print("  - a Linux or macOS machine.")
-        print("'rebound' alone is not enough; 'reboundx' must import successfully too.")
+        _printReboundUnavailable(include_install_help=True)
         sys.exit(1)
 
     ###

--- a/wmpl/Rebound/Tests/__init__.py
+++ b/wmpl/Rebound/Tests/__init__.py
@@ -1,0 +1,1 @@
+""" Tests for the REBOUND integration. """

--- a/wmpl/Rebound/Tests/test_REBOUND.py
+++ b/wmpl/Rebound/Tests/test_REBOUND.py
@@ -7,6 +7,7 @@ import io
 import os
 import runpy
 import types
+import sys
 
 import pytest
 
@@ -97,5 +98,10 @@ def testAvailableReboundDependenciesAreSilent(monkeypatch):
     module, import_output = _loadReboundModule()
 
     assert import_output == ""
-    assert module.REBOUND_FOUND
-    assert module._REBOUND_IMPORT_ERROR is None
+    if sys.platform != 'win32':
+        assert module.REBOUND_FOUND
+        assert module._REBOUND_IMPORT_ERROR is None
+    else:
+        # on Windows we expect the loader to error out
+        assert module.REBOUND_FOUND is False
+        assert module._REBOUND_IMPORT_ERROR is not None

--- a/wmpl/Rebound/Tests/test_REBOUND.py
+++ b/wmpl/Rebound/Tests/test_REBOUND.py
@@ -1,0 +1,101 @@
+""" Regression tests for optional REBOUND dependency reporting. """
+
+import builtins
+import contextlib
+import importlib.util
+import io
+import os
+import runpy
+import types
+
+import pytest
+
+
+REBOUND_PATH = os.path.join(os.path.dirname(os.path.dirname(__file__)), "REBOUND.py")
+
+
+def _mockReboundImports(monkeypatch, reboundx_found):
+    """ Mock the optional REBOUND imports without changing the installed environment. """
+
+    real_import = builtins.__import__
+    rebound = types.ModuleType("rebound")
+    reboundx = types.ModuleType("reboundx")
+    reboundx.constants = types.SimpleNamespace()
+
+    def mockedImport(name, globals=None, locals=None, fromlist=(), level=0):
+
+        if name == "rebound":
+            return rebound
+
+        if (name == "reboundx") or name.startswith("reboundx."):
+            if not reboundx_found:
+                raise ImportError("No module named 'reboundx'")
+
+            return reboundx
+
+        return real_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", mockedImport)
+
+
+def _loadReboundModule():
+    """ Load REBOUND.py under an isolated module name and capture its import-time output. """
+
+    spec = importlib.util.spec_from_file_location("_wmpl_test_rebound", REBOUND_PATH)
+    module = importlib.util.module_from_spec(spec)
+    stdout = io.StringIO()
+
+    with contextlib.redirect_stdout(stdout):
+        spec.loader.exec_module(module)
+
+    return module, stdout.getvalue()
+
+
+def testMissingReboundxIsSilentUntilUsed(monkeypatch):
+    """ A missing optional dependency must not produce output during an unrelated import. """
+
+    _mockReboundImports(monkeypatch, reboundx_found=False)
+    module, import_output = _loadReboundModule()
+
+    assert import_output == ""
+    assert not module.REBOUND_FOUND
+    assert module._REBOUND_IMPORT_ERROR == "No module named 'reboundx'"
+
+    for function, args in [
+            (module.convertToBarycentric, ([], 0)),
+            (module.reboundSimulate, (None, None))]:
+
+        stdout = io.StringIO()
+        with contextlib.redirect_stdout(stdout):
+            result = function(*args)
+
+        assert result is None
+        assert "packages are required" in stdout.getvalue()
+        assert "The error was: No module named 'reboundx'" in stdout.getvalue()
+
+
+def testMissingReboundxCommandLineError(monkeypatch):
+    """ Direct command-line use must report the cause, guidance, and a failing exit status. """
+
+    _mockReboundImports(monkeypatch, reboundx_found=False)
+    stdout = io.StringIO()
+
+    with pytest.raises(SystemExit) as exc_info:
+        with contextlib.redirect_stdout(stdout):
+            runpy.run_path(REBOUND_PATH, run_name="__main__")
+
+    assert exc_info.value.code == 1
+    assert "The error was: No module named 'reboundx'" in stdout.getvalue()
+    assert "pip install rebound reboundx" in stdout.getvalue()
+    assert "Windows Subsystem for Linux" in stdout.getvalue()
+
+
+def testAvailableReboundDependenciesAreSilent(monkeypatch):
+    """ Successful optional imports must preserve the normal REBOUND execution path. """
+
+    _mockReboundImports(monkeypatch, reboundx_found=True)
+    module, import_output = _loadReboundModule()
+
+    assert import_output == ""
+    assert module.REBOUND_FOUND
+    assert module._REBOUND_IMPORT_ERROR is None


### PR DESCRIPTION
# Problem Statement
At present, on Windows the import warnings at REBOUND.py lines 39-40 are printed by every thread that is launched. This can lead to dozens or hundreds of messages when running monte-carlo simulations for example in ECSV or CorrelateRMS.  These messages are swamping normal logging. 

# Root Cause
The issue arises because the wmpl contains an __init__ script that pre-loads every submodule including REBOUND. Consequently the import statement is retried in every thread that imports wmpl or any submodule or function. 

# Fix
This fix still traps the import failure but only reports it if REBOUND's __main__ function is called.  This is done by storing the import exception in a variable `rebound_err` and then printing it in the main function, if REBOUND_FOUND is false. 

# Testing
Tested on Windows 11 and WSL Ubuntu.  Output on Windows 11, where reboundx is not available, shown here:

``` bash
(wmpl) PS C:\dev\meteorhunting\wmpl_master> python -m wmpl.Rebound.REBOUND c:\temp\20260220_204658_trajectory.pickle

ERROR: the 'rebound' and 'reboundx' packages are required to run this script, but they could not be imported.
The error was: No module named 'reboundx'

Install them with:  pip install rebound reboundx

Note: on Windows, 'reboundx' has no prebuilt wheel and does not compile with the MSVC compiler (it uses C features MSVC lacks). Use one of:
  - Windows Subsystem for Linux (WSL2, e.g. Ubuntu) - recommended, builds cleanly, or
  - a Linux or macOS machine.
'rebound' alone is not enough; 'reboundx' must import successfully too.
(wmpl) PS C:\dev\meteorhunting\wmpl_master>
```

and the WSL Ubuntu result, which also produced a chart:
``` bash
(wmpl) markj@markslaptop3:/mnt/c/Users/markj/OneDrive/dev/meteorhunting/wmpl_master$ python -m wmpl.Rebound.REBOUND /mnt/c/temp/20260220_204658_trajectory.pickle
Using the local DE430 ephemeris for planet positions.

==============================================================================
  REBOUND orbit integration  |  20260220204658_B4sv6
==============================================================================
  Ephemeris    : local DE430
  Direction    : backward, 60.00 days
  Frame        : heliocentric
  Start epoch  : 2461092.365956 JD (TDB)
  Final epoch  : 2461032.365956 JD (TDB)  =  2025-12-22 20:46:58.592 UTC
  Runtime      : 1.5 s
------------------------------------------------------------------------------
  Final orbital elements   (nominal):

    a    =      2.642879  AU
    q    =      0.716780  AU
    e    =      0.728788
    i    =     26.313398  deg
    peri =     69.681985  deg
    node =    151.864974  deg
    f    =    250.013256  deg
------------------------------------------------------------------------------
  Close encounters (< 3 Hill radii): none detected
==============================================================================
  Saved report : /mnt/c/temp/rebound_simulation_results.txt
  Saved plot   : /mnt/c/temp/rebound_simulation.png
==============================================================================
(wmpl) markj@markslaptop3:/mnt/c/Users/markj/OneDrive/dev/meteorhunting/wmpl_master$